### PR TITLE
fix(docker): Update Rust base image to 1.94 to match toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.89-bookworm AS builder
+FROM rust:1.94-bookworm AS builder
 
 # Install build dependencies for image processing libraries (AVIF and HEIF)
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
- The Dockerfile was left at `rust:1.89-bookworm` when `rust-toolchain.toml` was bumped to 1.94.1 in #193
- Docker builds fail because AWS SDK crates (aws-config, aws-sdk-s3, aws-sdk-dynamodb, etc.) now require `rustc >=1.91.1`
- Updates the base image to `rust:1.94-bookworm` to match the project toolchain

## Notes
- CI (Ubuntu/macOS) failures on main are a separate transient issue: `aomedia.googlesource.com` is returning 503 when libavif-sys tries to download libaom. This is a Google infrastructure issue that resolves on retry.

## Test plan
- [ ] Docker build succeeds for both linux/amd64 and linux/arm64
- [ ] CI passes on this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)