### PR TITLE
chore(deps): Bump libavif-rs to new-libavif-v2 branch (libavif 1.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2812,8 +2812,8 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libaom-sys"
-version = "0.17.2+libaom.3.11.0"
-source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif#1064a16ed65190702c2f6b16640b139730f0c6e9"
+version = "0.17.2+libaom.3.13.1"
+source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif-v2#c90806692a15d0ef495c2ce2bf75cc70386f41e7"
 dependencies = [
  "cmake",
 ]
@@ -2821,15 +2821,15 @@ dependencies = [
 [[package]]
 name = "libavif"
 version = "0.14.0"
-source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif#1064a16ed65190702c2f6b16640b139730f0c6e9"
+source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif-v2#c90806692a15d0ef495c2ce2bf75cc70386f41e7"
 dependencies = [
  "libavif-sys",
 ]
 
 [[package]]
 name = "libavif-sys"
-version = "0.17.0+libavif.1.2.1"
-source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif#1064a16ed65190702c2f6b16640b139730f0c6e9"
+version = "0.17.0+libavif.1.3.0"
+source = "git+https://github.com/theatrus/libavif-rs?branch=new-libavif-v2#c90806692a15d0ef495c2ce2bf75cc70386f41e7"
 dependencies = [
  "cmake",
  "libaom-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ usvg = "0.47"
 ico = "0.5"
 webp = { version = "0.3", features = ["img"] }
 libwebp-sys = "0.14"
-libavif = { git = "https://github.com/theatrus/libavif-rs", branch = "new-libavif", features = ["codec-aom"] }
-libavif-sys = { git = "https://github.com/theatrus/libavif-rs", branch = "new-libavif", features = ["codec-aom"] }
+libavif = { git = "https://github.com/theatrus/libavif-rs", branch = "new-libavif-v2", default-features = false, features = ["codec-aom"] }
+libavif-sys = { git = "https://github.com/theatrus/libavif-rs", branch = "new-libavif-v2", default-features = false, features = ["codec-aom"] }
 libheif-rs = "2.7"
 rgb = "0.8"
 


### PR DESCRIPTION
## Summary
- Switches the `libavif` / `libavif-sys` git dependency to the `new-libavif-v2` branch of `theatrus/libavif-rs`.
- Brings in **libavif 1.3.0** (was 1.2.1) and **libaom 3.13.1** (was 3.11.0).
- Sets `default-features = false` because the new branch's `libavif-sys` defaults changed to `codec-dav1d` + `codec-rav1e`; we want only `codec-aom`.

The upstream branch also needed a build.rs fix (libavif 1.3.0 changed `AVIF_CODEC_AOM` from a BOOL to a STRING accepting `OFF`/`LOCAL`/`SYSTEM`); that fix is already on `new-libavif-v2`.

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — all suites pass (252 tenrankai tests + supporting crates), including the 15 AVIF tests under `gallery::image_processing::tests::avif_tests` and `composite_tests`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)