### PR TITLE
feat: Preview readiness gate for pre-generated images

### DIFF
--- a/tenrankai/src/api.rs
+++ b/tenrankai/src/api.rs
@@ -2616,6 +2616,7 @@ roles = ["viewer"]
                         }),
                         modification_date: None,
                         color_profile: Some("sRGB".to_string()),
+                        preview_ready: true,
                     },
                 )
                 .await;
@@ -2691,6 +2692,7 @@ roles = ["viewer"]
                         }),
                         modification_date: None,
                         color_profile: Some("sRGB".to_string()),
+                        preview_ready: true,
                     },
                 )
                 .await;

--- a/tenrankai/src/cache/persistent_cache.rs
+++ b/tenrankai/src/cache/persistent_cache.rs
@@ -195,6 +195,11 @@ where
         self.dirty.store(true, Ordering::Relaxed);
     }
 
+    /// Explicitly mark the cache as dirty (has unsaved changes).
+    pub fn mark_dirty(&self) {
+        self.dirty.store(true, Ordering::Relaxed);
+    }
+
     /// Check if the cache has unsaved changes.
     pub fn is_dirty(&self) -> bool {
         self.dirty.load(Ordering::Relaxed)

--- a/tenrankai/src/cache/queue/worker.rs
+++ b/tenrankai/src/cache/queue/worker.rs
@@ -120,6 +120,11 @@ impl CacheQueueWorker {
             error!("Failed to generate cache for {}: {}", request.image_path, e);
         } else {
             debug!("Generated cache for {}", request.image_path);
+            // Update readiness after generation
+            let fresh_cache_files = gallery.load_cache_file_set().await;
+            gallery
+                .update_preview_readiness(&request.image_path, &fresh_cache_files)
+                .await;
         }
     }
 

--- a/tenrankai/src/gallery/cache.rs
+++ b/tenrankai/src/gallery/cache.rs
@@ -410,7 +410,11 @@ impl Gallery {
             return true;
         }
 
-        let sizes = self.get_pregenerate_sizes();
+        let sizes: Vec<_> = self
+            .get_pregenerate_sizes()
+            .into_iter()
+            .filter(|s| !s.is_tile())
+            .collect();
         let allowed_formats = self.get_pregenerate_formats();
         if sizes.is_empty() || allowed_formats.is_empty() {
             return true;

--- a/tenrankai/src/gallery/cache.rs
+++ b/tenrankai/src/gallery/cache.rs
@@ -411,13 +411,17 @@ impl Gallery {
         }
 
         let sizes = self.get_pregenerate_sizes();
-        if sizes.is_empty() {
+        let allowed_formats = self.get_pregenerate_formats();
+        if sizes.is_empty() || allowed_formats.is_empty() {
             return true;
         }
 
         let is_ready = sizes.iter().all(|size| {
             let coverage = self.check_format_coverage_fast(relative_path, *size, cache_files);
-            coverage.is_complete(relative_path)
+            coverage
+                .missing_formats(relative_path)
+                .into_iter()
+                .all(|format| !allowed_formats.contains(&format))
         });
 
         let mut cache = self.image_cache.write_all().await;
@@ -1232,6 +1236,82 @@ mod tests {
         // Verify the hash part is consistent
         let hash = gallery.generate_image_cache_key("test.jpg", "thumbnail", "webp", false);
         assert_eq!(filename, format!("{}.webp", hash));
+    }
+
+    #[tokio::test]
+    async fn test_preview_readiness_respects_configured_formats() {
+        use super::super::ImageMetadata;
+        use std::collections::HashSet;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let source_dir = temp_dir.path().join("photos");
+        let cache_dir = temp_dir.path().join("cache");
+
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        let config = crate::GallerySystemConfig {
+            name: "test".to_string(),
+            source_directory: source_dir.to_string_lossy().to_string(),
+            cache_directory: cache_dir.to_string_lossy().to_string(),
+            gallery_template: "gallery.html".to_string(),
+            image_detail_template: "image.html".to_string(),
+            pregenerate: Some(crate::PregenerateConfig {
+                formats: crate::config::defaults::default_pregenerate_formats(),
+                sizes: crate::config::defaults::default_pregenerate_sizes(),
+                tiles: false,
+            }),
+            ..Default::default()
+        };
+
+        let source_storage = create_test_storage_from_path(&source_dir);
+        let cache_storage = create_test_storage(&config.cache_directory);
+        let gallery = Gallery::new(config, source_storage, cache_storage);
+
+        gallery
+            .image_cache
+            .insert(
+                "test.jpg".to_string(),
+                ImageMetadata {
+                    dimensions: (100, 100),
+                    capture_date: None,
+                    camera_info: None,
+                    location_info: None,
+                    modification_date: None,
+                    color_profile: None,
+                    preview_ready: false,
+                },
+            )
+            .await;
+
+        let mut cache_files = HashSet::new();
+        for size in [
+            super::ImageSize::Thumbnail,
+            super::ImageSize::ThumbnailRetina,
+            super::ImageSize::Gallery,
+            super::ImageSize::GalleryRetina,
+            super::ImageSize::Medium,
+            super::ImageSize::MediumRetina,
+        ] {
+            for format in ["jpg", "webp"] {
+                cache_files.insert(gallery.generate_cache_filename(
+                    "test.jpg",
+                    &size.as_str(),
+                    format,
+                    false,
+                ));
+            }
+        }
+
+        assert!(
+            gallery
+                .update_preview_readiness("test.jpg", &cache_files)
+                .await
+        );
+
+        let cache = gallery.image_cache.read_all().await;
+        assert!(cache.get("test.jpg").unwrap().preview_ready);
     }
 
     #[tokio::test]

--- a/tenrankai/src/gallery/cache.rs
+++ b/tenrankai/src/gallery/cache.rs
@@ -526,13 +526,13 @@ impl Gallery {
                     relative_path,
                     elapsed.as_secs_f32()
                 );
+                Ok(())
             }
             Err(e) => {
                 error!("Failed to generate cache for {}: {}", relative_path, e);
+                Err(e)
             }
         }
-
-        Ok(())
     }
 
     /// Pre-generate tiles for a single image
@@ -707,6 +707,16 @@ impl Gallery {
 
                     match &result {
                         Ok(_) => {
+                            // Mark image as preview-ready immediately so it appears in listings
+                            let mut cache = gallery.image_cache.write_all().await;
+                            if let Some(metadata) = cache.get_mut(&image_path)
+                                && !metadata.preview_ready
+                            {
+                                metadata.preview_ready = true;
+                                drop(cache);
+                                gallery.image_cache.mark_dirty();
+                            }
+
                             let count = completed.fetch_add(1, Ordering::Relaxed) + 1;
                             if count.is_multiple_of(10) || count == total_images {
                                 info!("Pre-generated cache for {}/{} images", count, total_images);

--- a/tenrankai/src/gallery/cache.rs
+++ b/tenrankai/src/gallery/cache.rs
@@ -395,6 +395,43 @@ impl Gallery {
             && self.config.tiles.is_some()
     }
 
+    pub fn is_pregeneration_enabled(&self) -> bool {
+        self.config.pregenerate.is_some()
+    }
+
+    /// Check format coverage for an image and update its preview_ready flag.
+    /// Returns the new readiness value.
+    pub async fn update_preview_readiness(
+        &self,
+        relative_path: &str,
+        cache_files: &HashSet<String>,
+    ) -> bool {
+        if !self.is_pregeneration_enabled() {
+            return true;
+        }
+
+        let sizes = self.get_pregenerate_sizes();
+        if sizes.is_empty() {
+            return true;
+        }
+
+        let is_ready = sizes.iter().all(|size| {
+            let coverage = self.check_format_coverage_fast(relative_path, *size, cache_files);
+            coverage.is_complete(relative_path)
+        });
+
+        let mut cache = self.image_cache.write_all().await;
+        if let Some(metadata) = cache.get_mut(relative_path)
+            && metadata.preview_ready != is_ready
+        {
+            metadata.preview_ready = is_ready;
+            drop(cache);
+            self.image_cache.mark_dirty();
+        }
+
+        is_ready
+    }
+
     /// Pre-generate cache for a single image (only generates missing formats)
     pub async fn pregenerate_image_cache(
         &self,
@@ -707,6 +744,36 @@ impl Gallery {
 
         if total_failed > 0 && !was_cancelled {
             warn!("{} images failed during cache pre-generation", total_failed);
+        }
+
+        // Update preview readiness flags for all images
+        if self.is_pregeneration_enabled() && !was_cancelled {
+            info!("Updating preview readiness flags...");
+            let fresh_cache_files = self.load_cache_file_set().await;
+            let all_paths: Vec<String> = {
+                let cache = self.image_cache.read_all().await;
+                cache.keys().cloned().collect()
+            };
+            let mut ready_count = 0usize;
+            let mut not_ready_count = 0usize;
+            for path in &all_paths {
+                if self
+                    .update_preview_readiness(path, &fresh_cache_files)
+                    .await
+                {
+                    ready_count += 1;
+                } else {
+                    not_ready_count += 1;
+                }
+            }
+            info!(
+                "Preview readiness: {} ready, {} not ready",
+                ready_count, not_ready_count
+            );
+
+            if let Err(e) = self.save_metadata_cache().await {
+                error!("Failed to save readiness flags: {}", e);
+            }
         }
 
         Ok(())
@@ -1310,6 +1377,7 @@ Hidden folder
             location_info: None,
             modification_date: None,
             color_profile: None,
+            preview_ready: false,
         };
 
         {
@@ -1369,6 +1437,7 @@ Hidden folder
             location_info: None,
             modification_date: None,
             color_profile: None,
+            preview_ready: false,
         };
 
         {
@@ -1467,6 +1536,7 @@ Hidden folder
             location_info: None,
             modification_date: None,
             color_profile: None,
+            preview_ready: false,
         };
 
         {

--- a/tenrankai/src/gallery/core.rs
+++ b/tenrankai/src/gallery/core.rs
@@ -41,6 +41,21 @@ impl Gallery {
     ) -> Result<Vec<GalleryItem>, GalleryError> {
         let mut items = Vec::new();
 
+        // Pre-compute set of ready images when pregeneration is enabled
+        let ready_images: Option<std::collections::HashSet<String>> =
+            if self.is_pregeneration_enabled() {
+                let cache = self.image_cache.read_all().await;
+                Some(
+                    cache
+                        .iter()
+                        .filter(|(_, m)| m.preview_ready)
+                        .map(|(k, _)| k.clone())
+                        .collect(),
+                )
+            } else {
+                None
+            };
+
         // Add subdirectories from cache
         for subdir_name in &cached.subdirectories {
             let subdir_path = if relative_path.is_empty() {
@@ -69,6 +84,11 @@ impl Gallery {
                 .map(|sc| {
                     sc.preview_items
                         .iter()
+                        .filter(|p| {
+                            ready_images
+                                .as_ref()
+                                .is_none_or(|ready| ready.contains(&p.path))
+                        })
                         .map(|p| p.thumbnail_url.clone())
                         .collect()
                 })
@@ -105,6 +125,16 @@ impl Gallery {
         } else {
             // Fall back to flat image list for backward compatibility
             cached.images.iter().map(|s| s.as_str()).collect()
+        };
+
+        // Filter out non-ready images when pregeneration is enabled
+        let image_paths: Vec<&str> = if let Some(ref ready) = ready_images {
+            image_paths
+                .into_iter()
+                .filter(|path| ready.contains(*path))
+                .collect()
+        } else {
+            image_paths
         };
 
         // Get hidden images list and check user permissions
@@ -879,9 +909,20 @@ impl Gallery {
         if let Ok(perms) = resolver.resolve_user_permissions(user)
             && perms.can_view
         {
+            // Filter out non-ready images when pregeneration is enabled
+            let preview_items: Vec<_> = if self.is_pregeneration_enabled() {
+                let cache = self.image_cache.read_all().await;
+                cached
+                    .preview_items
+                    .iter()
+                    .filter(|p| cache.get(&p.path).map(|m| m.preview_ready).unwrap_or(false))
+                    .collect()
+            } else {
+                cached.preview_items.iter().collect()
+            };
+
             // Convert cached preview items to GalleryItem (minimal conversion)
-            let mut items: Vec<GalleryItem> = cached
-                .preview_items
+            let mut items: Vec<GalleryItem> = preview_items
                 .iter()
                 .map(|p| GalleryItem {
                     name: p.path.rsplit('/').next().unwrap_or(&p.path).to_string(),

--- a/tenrankai/src/gallery/core.rs
+++ b/tenrankai/src/gallery/core.rs
@@ -41,7 +41,7 @@ impl Gallery {
     ) -> Result<Vec<GalleryItem>, GalleryError> {
         let mut items = Vec::new();
 
-        // Pre-compute set of ready images when pregeneration is enabled
+        // Pre-compute set of ready images and per-folder ready counts
         let ready_images: Option<std::collections::HashSet<String>> =
             if self.is_pregeneration_enabled() {
                 let cache = self.image_cache.read_all().await;
@@ -55,6 +55,27 @@ impl Gallery {
             } else {
                 None
             };
+
+        let ready_folder_counts: Option<std::collections::HashMap<String, usize>> =
+            ready_images.as_ref().map(|ready| {
+                let mut counts: std::collections::HashMap<String, usize> =
+                    std::collections::HashMap::new();
+                for path in ready {
+                    let mut folder = path
+                        .rfind('/')
+                        .map(|i| path[..i].to_string())
+                        .unwrap_or_default();
+                    *counts.entry(folder.clone()).or_default() += 1;
+                    while let Some(slash) = folder.rfind('/') {
+                        folder.truncate(slash);
+                        *counts.entry(folder.clone()).or_default() += 1;
+                    }
+                    if !folder.is_empty() {
+                        *counts.entry(String::new()).or_default() += 1;
+                    }
+                }
+                counts
+            });
 
         // Add subdirectories from cache
         for subdir_name in &cached.subdirectories {
@@ -74,10 +95,14 @@ impl Gallery {
                     (None, None, None)
                 };
 
-            let item_count = subdir_cached
-                .as_ref()
-                .map(|sc| sc.recursive_image_count)
-                .unwrap_or(0);
+            let item_count = if let Some(ref counts) = ready_folder_counts {
+                counts.get(&subdir_path).copied().unwrap_or(0)
+            } else {
+                subdir_cached
+                    .as_ref()
+                    .map(|sc| sc.recursive_image_count)
+                    .unwrap_or(0)
+            };
 
             let preview_images: Vec<String> = subdir_cached
                 .as_ref()

--- a/tenrankai/src/gallery/metadata.rs
+++ b/tenrankai/src/gallery/metadata.rs
@@ -1484,6 +1484,7 @@ impl Gallery {
             location_info,
             modification_date,
             color_profile,
+            preview_ready: false,
         })
     }
 

--- a/tenrankai/src/gallery/mod.rs
+++ b/tenrankai/src/gallery/mod.rs
@@ -356,6 +356,34 @@ impl Gallery {
 
         self.metadata_generation.notify_waiters();
 
+        // Validate preview readiness flags against current cache state
+        if self.is_pregeneration_enabled() {
+            info!("Validating preview readiness flags...");
+            let cache_files = self.load_cache_file_set().await;
+            let all_paths: Vec<String> = {
+                let cache = self.image_cache.read_all().await;
+                cache.keys().cloned().collect()
+            };
+            let mut ready = 0usize;
+            let mut not_ready = 0usize;
+            for path in &all_paths {
+                if self.update_preview_readiness(path, &cache_files).await {
+                    ready += 1;
+                } else {
+                    not_ready += 1;
+                }
+            }
+            info!(
+                "Preview readiness validation: {} ready, {} not ready out of {} images",
+                ready,
+                not_ready,
+                all_paths.len()
+            );
+            if let Err(e) = self.save_metadata_cache().await {
+                error!("Failed to save readiness flags: {}", e);
+            }
+        }
+
         // Report format coverage status
         if let Err(e) = self.report_format_coverage().await {
             error!("Failed to report format coverage: {}", e);

--- a/tenrankai/src/gallery/types.rs
+++ b/tenrankai/src/gallery/types.rs
@@ -308,6 +308,8 @@ pub(crate) struct ImageMetadata {
     pub location_info: Option<LocationInfo>,
     pub modification_date: Option<SystemTime>,
     pub color_profile: Option<String>,
+    #[serde(default)]
+    pub preview_ready: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- New images are hidden from listings/API until all their preview sizes are built, preventing the server from being swamped by on-demand generation when many images appear at once
- Images appear progressively as each finishes processing, not all at once at the end
- Folder item counts reflect only ready images, matching what users actually see
- Zoom tiles are excluded from the readiness check
- `preview_ready` flag is persisted in the metadata cache and re-validated against actual format coverage on each background refresh cycle
- Only applies when pre-generation is enabled; on-demand mode is unchanged
- Direct URL access to non-ready images still works via on-demand fallback

## Test plan
- [x] All 453 tests pass (`cargo test --no-default-features`)
- [x] clippy and fmt clean
- [ ] Manual test with pre-generation enabled: verify images trickle in during processing
- [ ] Verify folder counts update as images become ready
- [ ] Verify server restart preserves readiness flags (no gallery flash)
- [ ] Verify on-demand mode (no pregenerate config) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)