### PR TITLE
fix: Browser back/forward on image detail page

### DIFF
--- a/frontend/react/pages/image-detail.tsx
+++ b/frontend/react/pages/image-detail.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { ImageDetailData } from '../types/index.ts';
 import { useImageDetail } from '../hooks/useImageDetail.ts';
@@ -145,6 +145,23 @@ export function ImageDetailPage({
       }
     }
   });
+
+  // Handle browser back/forward navigation
+  useEffect(() => {
+    const handlePopState = () => {
+      const detailPrefix = `${galleryUrl}/detail/`;
+      const path = window.location.pathname;
+      if (path.startsWith(detailPrefix)) {
+        const imagePath = decodeURIComponent(path.slice(detailPrefix.length));
+        if (imagePath && imagePath !== currentData?.image.path) {
+          loadImage(imagePath);
+        }
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, [galleryUrl, loadImage, currentData?.image.path]);
 
   // Preload previous and next images for faster navigation
   useImagePreload(currentData?.prev_image, currentData?.next_image);


### PR DESCRIPTION
## Summary
- Added `popstate` event listener to the image detail page so browser back/forward buttons correctly load the corresponding image
- Previously, `pushState` was used for SPA navigation between images but there was no listener for the reverse direction
- The fix extracts the image path from the URL on popstate and calls `loadImage()` to fetch and render the correct image data

## Test plan
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Manually verified: navigate between images with arrow keys/clicks, then use browser back/forward — image updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)