### PR TITLE
fix: Run npm install before admin build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "npm run build:legacy && vite build && npm run build:admin",
     "build:prod": "npm run build:legacy && vite build --mode production && npm run build:admin",
     "build:legacy": "tsc -p tsconfig.legacy.json",
-    "build:admin": "cd admin && npm run build",
+    "build:admin": "cd admin && npm install --silent && npm run build",
     "watch:legacy": "tsc -p tsconfig.legacy.json --watch",
     "dev": "vite",
     "dev:admin": "cd admin && npm run dev",


### PR DESCRIPTION
## Summary
- The admin directory has its own node_modules that isn't updated by the root `npm install`, causing stale dependency versions during builds
- `build:admin` now runs `npm install --silent` before `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)