### PR TITLE
fix(security): Remove download permission from default viewer role

### DIFF
--- a/tenrankai/src/permissions/resolver.rs
+++ b/tenrankai/src/permissions/resolver.rs
@@ -217,7 +217,6 @@ impl<'a> PermissionResolver<'a> {
     fn default_viewer_permissions(&self) -> RolePermissions {
         RolePermissions {
             can_view: true,
-            can_download_medium: true,
             ..Default::default()
         }
     }
@@ -254,7 +253,7 @@ mod tests {
 
         let perms = resolver.resolve_user_permissions(None).unwrap();
         assert!(perms.can_view);
-        assert!(perms.can_download_medium);
+        assert!(!perms.can_download_medium);
         assert!(!perms.can_see_technical_details);
     }
 

--- a/tenrankai/src/permissions/types.rs
+++ b/tenrankai/src/permissions/types.rs
@@ -260,7 +260,6 @@ impl PermissionConfig {
                 "viewer".to_string(),
                 RolePermissions {
                     can_view: true,
-                    can_download_medium: true,
                     ..Default::default()
                 },
             ),
@@ -361,7 +360,7 @@ mod tests {
         // Check viewer role
         let viewer = roles.get("viewer").unwrap();
         assert!(viewer.permissions.can_view);
-        assert!(viewer.permissions.can_download_medium);
+        assert!(!viewer.permissions.can_download_medium);
         assert!(!viewer.permissions.can_see_technical_details);
 
         // Check contributor role


### PR DESCRIPTION
## Summary
- Default viewer role no longer grants `can_download_medium`
- This was showing download buttons to logged-out users
- Authenticated users (contributor role) still get downloads
- Sites wanting public downloads can explicitly configure it in their permission config

## Test plan
- [x] All tests pass (updated viewer permission assertions)
- [ ] Verify logged-out users no longer see download buttons
- [ ] Verify logged-in users still see download buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)