### PR TITLE
feat(ui): Surface Download Original button when permitted

### DIFF
--- a/frontend/react/components/ImageDetail/ImageControls.tsx
+++ b/frontend/react/components/ImageDetail/ImageControls.tsx
@@ -15,12 +15,23 @@ export function ImageControls({ image, permissions, onEditClick, shareUrl, baseU
   const imageBaseUrl = image.medium_url.replace(/\/medium$/, '');
   const largeUrl = `${imageBaseUrl}/large`;
 
-  const canDownloadLarge = permissions.can_download_large;
+  const canDownloadOriginal = permissions.can_download_original;
+  const canDownloadLarge = permissions.can_download_large || canDownloadOriginal;
   const canDownloadMedium = permissions.can_download_medium || canDownloadLarge;
 
   // Determine best available download option
-  const downloadUrl = canDownloadLarge ? largeUrl : `${imageBaseUrl}/medium`;
-  const downloadLabel = canDownloadLarge ? 'Download Large' : 'Download';
+  let downloadUrl: string;
+  let downloadLabel: string;
+  if (canDownloadOriginal) {
+    downloadUrl = imageBaseUrl;
+    downloadLabel = 'Download Original';
+  } else if (canDownloadLarge) {
+    downloadUrl = largeUrl;
+    downloadLabel = 'Download Large';
+  } else {
+    downloadUrl = `${imageBaseUrl}/medium`;
+    downloadLabel = 'Download';
+  }
 
   // Show edit button when user can edit and there's no title/description
   const showEditButton = permissions.can_edit_content && !image.title && !image.description && onEditClick;


### PR DESCRIPTION
## Summary
- `permissions.can_download_original` was declared on the frontend `RolePermissions` type but never consumed by any component, so users with the permission saw at most a "Download Large" button and had to construct the original URL by hand.
- `ImageControls` now picks Original as the highest-priority download (Original → Large → Medium), mirroring the existing fallback pattern.
- Backend gate is unchanged — the route at `tenrankai/src/gallery/handlers.rs:590` still enforces `can_download_original`.

## Test plan
- [ ] Visit an image as a user whose role has `can_download_original = true` and confirm the primary action reads "Download Original" and links to the un-suffixed image URL.
- [ ] Visit as a user with only `can_download_large` and confirm the button still reads "Download Large".
- [ ] Visit as a user with only `can_download_medium` and confirm the button reads "Download" and points at `/medium`.
- [ ] Visit as a user with no download permissions and confirm the "Request Download Access" fallback is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)