### PR TITLE
Move image description out of nav strip into its own section

### DIFF
--- a/frontend/react/components/ImageDetail/ImageNavigation.tsx
+++ b/frontend/react/components/ImageDetail/ImageNavigation.tsx
@@ -9,7 +9,6 @@ interface ImageNavigationProps {
   onNavigate?: (direction: 'prev' | 'next') => void;
   onNavigateToImage?: (image: NavigationImage) => void;
   title?: string;
-  description?: string;
   canEditContent?: boolean;
   onEditClick?: () => void;
 }
@@ -23,7 +22,6 @@ export function ImageNavigation({
   onNavigate,
   onNavigateToImage,
   title,
-  description,
   canEditContent,
   onEditClick
 }: ImageNavigationProps) {
@@ -118,11 +116,11 @@ export function ImageNavigation({
         )}
       </div>
 
-      {/* Image title and description - desktop only (only show when there's content) */}
-      {(title || description) && (
+      {/* Image title - desktop only */}
+      {title ? (
         <div className="nav-image-info hide-mobile">
           <div className="image-title-row">
-            {title && <h2 className="nav-image-title">{title}</h2>}
+            <h2 className="nav-image-title">{title}</h2>
             {canEditContent && onEditClick && (
               <button
                 type="button"
@@ -137,17 +135,10 @@ export function ImageNavigation({
               </button>
             )}
           </div>
-          {description && (
-            <div
-              className="nav-image-description"
-              dangerouslySetInnerHTML={{ __html: description }}
-            />
-          )}
         </div>
+      ) : (
+        <div className="nav-spacer"></div>
       )}
-
-      {/* Spacer when no title/description */}
-      {!title && !description && <div className="nav-spacer"></div>}
 
       {/* Next images strip */}
       <div className="nav-strip nav-strip-next">

--- a/frontend/react/pages/image-detail.tsx
+++ b/frontend/react/pages/image-detail.tsx
@@ -250,7 +250,6 @@ export function ImageDetailPage({
             onNavigate={handleNavigation}
             onNavigateToImage={handleNavigateToImage}
             title={currentData.image.title}
-            description={currentData.image.description}
             canEditContent={currentData.permissions.can_edit_content}
             onEditClick={() => setIsEditModalOpen(true)}
           />
@@ -277,6 +276,16 @@ export function ImageDetailPage({
           )}
         </div>
         
+        {/* Image description - shown when description exists */}
+        {currentData.image.description && (
+          <div className="image-description-section hide-mobile">
+            <div
+              className="image-description-content"
+              dangerouslySetInnerHTML={{ __html: currentData.image.description }}
+            />
+          </div>
+        )}
+
         {/* Info section - below the image viewer */}
         <div className="image-info-section">
           {/* Hidden image indicator */}

--- a/static/image-detail.css
+++ b/static/image-detail.css
@@ -339,17 +339,25 @@ body {
     color: var(--text-primary);
 }
 
-.nav-image-description {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    line-height: 1.5;
+/* Image description section - between navigation and metadata */
+.image-description-section {
+    max-width: 800px;
+    margin: var(--spacing-lg) auto 0;
+    padding: 0 var(--spacing-xl);
+    text-align: center;
 }
 
-.nav-image-description p {
+.image-description-content {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.image-description-content p {
     margin: 0 0 0.5rem 0;
 }
 
-.nav-image-description p:last-child {
+.image-description-content p:last-child {
     margin-bottom: 0;
 }
 


### PR DESCRIPTION
## Summary
- Removed the markdown description from the navigation strip center box (which could overflow and overlap the metadata below)
- Added a new dedicated `image-description-section` between the nav strip and the info/metadata section
- Nav strip center now shows only the image title

## Test plan
- [ ] View an image with a long markdown description — verify it no longer overlaps metadata
- [ ] View an image with only a title (no description) — nav strip should show title, no description section rendered
- [ ] View an image with no title or description — nav strip shows spacer, no description section
- [ ] Verify mobile layout is unaffected (description section is hidden via `hide-mobile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)