### PR TITLE
feat(sitemap): Generate sitemap.xml automatically per site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Automatic `sitemap.xml`**: Generated per site at `/sitemap.xml` covering all publicly visible resources
+  - Includes static pages (`pages/*.html.liquid`), publicly viewable gallery folders and image detail pages, and posts
+  - Respects per-folder permissions — folders requiring authentication (and their images) are excluded; hidden folders are never listed
+  - Splits into a `<sitemapindex>` with `/sitemap/<chunk>.xml` files when the URL count exceeds the 50,000-per-file limit
+  - Result is cached per site (rebuilt at most every 5 minutes) so crawler traffic doesn't re-walk the gallery tree on every request
+  - `robots.txt` now advertises the sitemap location when `base_url` is configured
+
 - **Pluggable Storage Abstraction**: Full S3 support for all storage operations
   - Unified `Storage` trait with async read, write, list, delete, and metadata operations
   - Filesystem backend (default) and S3 backend with presigned URL support

--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,20 @@ Place the following in one of your static directories:
 
 The system will search all configured directories in order to find these files.
 
+## Sitemap
+
+A `sitemap.xml` is generated automatically (per site) at `/sitemap.xml`. It lists
+all publicly visible resources: static pages (`pages/*.html.liquid`), publicly
+viewable gallery folders and image detail pages, and posts. Folders that require
+authentication — and the images inside them — are omitted, and hidden folders are
+never listed.
+
+When a site has more URLs than fit in a single sitemap file (the protocol limit is
+50,000), `/sitemap.xml` becomes a sitemap index that references `/sitemap/<chunk>.xml`
+files. The generated sitemap is cached per site and rebuilt at most every five minutes.
+The default `robots.txt` advertises the sitemap when `base_url` is configured; the
+sitemap endpoint is only served when `base_url` is set, since it requires absolute URLs.
+
 ## Logging
 
 Control logging verbosity with the `RUST_LOG` environment variable or `--log-level` flag:

--- a/tenrankai/Cargo.toml
+++ b/tenrankai/Cargo.toml
@@ -116,13 +116,13 @@ zip.workspace = true
 num_cpus.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true
+tempfile.workspace = true
 
 # Logging
 tracing-subscriber.workspace = true
 env_logger.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 axum-test.workspace = true
 regex.workspace = true
 zip.workspace = true
@@ -172,3 +172,7 @@ required-features = ["avif"]
 [[test]]
 name = "admin_and_hidden_images_tests"
 path = "../tests/admin_and_hidden_images_tests.rs"
+
+[[test]]
+name = "sitemap_integration"
+path = "../tests/sitemap_integration.rs"

--- a/tenrankai/src/lib.rs
+++ b/tenrankai/src/lib.rs
@@ -18,6 +18,7 @@ pub mod posts;
 pub mod robots;
 pub mod short_url;
 pub mod site;
+pub mod sitemap;
 pub mod startup_checks;
 pub mod static_files;
 pub mod template_system;
@@ -355,6 +356,14 @@ fn create_router(app_state: AppState, built_site: Arc<site::Site>) -> axum::Rout
         .route(
             "/robots.txt",
             axum::routing::get(robots::robots_txt_handler),
+        )
+        .route(
+            "/sitemap.xml",
+            axum::routing::get(sitemap::sitemap_index_handler),
+        )
+        .route(
+            "/sitemap/{file}",
+            axum::routing::get(sitemap::sitemap_chunk_handler),
         )
         .route("/theme.css", axum::routing::get(theme::serve_theme_css))
         .route("/static/{*path}", axum::routing::get(static_file_handler))

--- a/tenrankai/src/robots.rs
+++ b/tenrankai/src/robots.rs
@@ -33,16 +33,22 @@ pub async fn robots_txt_handler(ResolvedState(app_state): ResolvedState) -> Resp
     }
 
     // Return default permissive robots.txt
-    let default_robots = r#"# robots.txt for Tenrankai Gallery
-# This file allows all web crawlers to access all content
+    let mut default_robots = String::from(
+        "# robots.txt for Tenrankai Gallery\n\
+         # This file allows all web crawlers to access all content\n\
+         \n\
+         User-agent: *\n\
+         Allow: /\n\
+         Crawl-delay: 1\n",
+    );
 
-User-agent: *
-Allow: /
-Crawl-delay: 1
-
-# Sitemap location (if you have one)
-# Sitemap: /sitemap.xml
-"#;
+    // Advertise the auto-generated sitemap when an absolute base URL is known.
+    if let Some(base_url) = app_state.base_url() {
+        let base_url = base_url.trim_end_matches('/');
+        if !base_url.is_empty() {
+            default_robots.push_str(&format!("\nSitemap: {base_url}/sitemap.xml\n"));
+        }
+    }
 
     (
         StatusCode::OK,

--- a/tenrankai/src/sitemap.rs
+++ b/tenrankai/src/sitemap.rs
@@ -1,0 +1,538 @@
+//! Automatic `sitemap.xml` generation for publicly visible resources.
+//!
+//! The sitemap is generated per site (resolved from the request via
+//! [`ResolvedState`]). It covers static pages (`pages/*.html.liquid`), publicly
+//! viewable gallery folders and image detail pages, and posts. When the total
+//! number of URLs exceeds [`MAX_URLS_PER_SITEMAP`] the response at `/sitemap.xml`
+//! becomes a sitemap index that points at `/sitemap/<chunk>.xml` files instead
+//! of a single `<urlset>`.
+//!
+//! Generated documents are rendered once and written to a per-site temporary
+//! directory; requests serve those files until the [`SITEMAP_CACHE_TTL`]
+//! expires. This keeps crawler traffic from re-walking the gallery tree and
+//! keeps the (potentially large) rendered XML out of resident memory.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex, OnceLock, PoisonError},
+    time::{Duration, Instant},
+};
+
+use axum::{
+    extract::Path,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use tempfile::TempDir;
+
+use crate::{AppState, permissions::resolve_permissions_for_path, site::ResolvedState};
+
+/// Maximum number of `<url>` entries in a single sitemap file. The sitemap
+/// protocol allows up to 50,000; we keep headroom for safety.
+const MAX_URLS_PER_SITEMAP: usize = 45_000;
+
+/// How long a generated sitemap is reused before being rebuilt. Keeping this
+/// short bounds staleness; keeping it non-zero lets a crawler fetch the sitemap
+/// index and every chunk without re-walking the gallery tree on each request.
+const SITEMAP_CACHE_TTL: Duration = Duration::from_secs(300);
+
+const SITEMAP_XMLNS: &str = "http://www.sitemaps.org/schemas/sitemap/0.9";
+const XML_CONTENT_TYPE: &str = "application/xml; charset=utf-8";
+
+/// A single `<url>` entry in a sitemap.
+struct UrlEntry {
+    loc: String,
+    /// W3C datetime string, if known.
+    lastmod: Option<String>,
+}
+
+impl UrlEntry {
+    fn new(loc: String) -> Self {
+        Self { loc, lastmod: None }
+    }
+
+    fn with_lastmod(loc: String, lastmod: String) -> Self {
+        Self {
+            loc,
+            lastmod: Some(lastmod),
+        }
+    }
+}
+
+/// What document a request wants from the generated sitemap.
+enum SitemapTarget {
+    /// `/sitemap.xml` — either a single `<urlset>` or a `<sitemapindex>`.
+    Index,
+    /// `/sitemap/<id>.xml` — one `<urlset>` chunk.
+    Chunk(String),
+}
+
+/// `GET /sitemap.xml`
+///
+/// Returns a `<urlset>` directly when everything fits in one file, or a
+/// `<sitemapindex>` referencing `/sitemap/<chunk>.xml` files otherwise.
+pub async fn sitemap_index_handler(ResolvedState(app_state): ResolvedState) -> Response {
+    let Some(base_url) = site_base_url(&app_state) else {
+        return base_url_missing();
+    };
+    match sitemap_bytes(&app_state, &base_url, &SitemapTarget::Index).await {
+        Some(bytes) => xml_response(bytes),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// `GET /sitemap/{file}` — serves an individual sitemap chunk referenced by the
+/// sitemap index. Only present when the sitemap is large enough to be split.
+pub async fn sitemap_chunk_handler(
+    ResolvedState(app_state): ResolvedState,
+    Path(file): Path<String>,
+) -> Response {
+    let Some(base_url) = site_base_url(&app_state) else {
+        return base_url_missing();
+    };
+    let Some(id) = file.strip_suffix(".xml") else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    match sitemap_bytes(&app_state, &base_url, &SitemapTarget::Chunk(id.to_string())).await {
+        Some(bytes) => xml_response(bytes),
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// A generated sitemap persisted to a per-site temporary directory. The
+/// directory holds `index.xml` plus one `<id>.xml` per chunk; it is removed
+/// when this value (and any in-flight reads holding a clone) are dropped.
+struct CachedSitemap {
+    base_url: String,
+    built_at: Instant,
+    dir: TempDir,
+    /// Chunk ids with a file on disk; empty unless the sitemap was split.
+    chunk_ids: Vec<String>,
+}
+
+impl CachedSitemap {
+    fn path_for(&self, target: &SitemapTarget) -> Option<std::path::PathBuf> {
+        match target {
+            SitemapTarget::Index => Some(self.dir.path().join("index.xml")),
+            SitemapTarget::Chunk(id) => self
+                .chunk_ids
+                .iter()
+                .any(|known| known == id)
+                .then(|| self.dir.path().join(format!("{id}.xml"))),
+        }
+    }
+}
+
+fn sitemap_cache() -> &'static Mutex<HashMap<String, Arc<CachedSitemap>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<CachedSitemap>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn fresh_cached_sitemap(app_state: &AppState, base_url: &str) -> Option<Arc<CachedSitemap>> {
+    let cache = sitemap_cache()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    let entry = cache.get(app_state.app_name())?;
+    (entry.base_url == base_url && entry.built_at.elapsed() < SITEMAP_CACHE_TTL)
+        .then(|| entry.clone())
+}
+
+fn store_cached_sitemap(app_state: &AppState, entry: Arc<CachedSitemap>) {
+    sitemap_cache()
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+        .insert(app_state.app_name().to_string(), entry);
+}
+
+/// Return the bytes of the requested sitemap document, using the per-site cache
+/// when fresh and rebuilding (and re-persisting) otherwise. Returns `None` only
+/// when a chunk that does not exist was requested. If the temporary directory
+/// cannot be written, the freshly rendered document is served directly without
+/// caching.
+async fn sitemap_bytes(
+    app_state: &AppState,
+    base_url: &str,
+    target: &SitemapTarget,
+) -> Option<Vec<u8>> {
+    if let Some(entry) = fresh_cached_sitemap(app_state, base_url) {
+        match entry.path_for(target) {
+            Some(path) => {
+                if let Ok(bytes) = std::fs::read(&path) {
+                    return Some(bytes);
+                }
+                // Fall through and rebuild on a read error (e.g. directory was
+                // pruned from under us).
+            }
+            None => return None,
+        }
+    }
+
+    let (index_doc, chunk_docs) = render_documents(app_state, base_url).await;
+
+    if let Some(entry) = persist_documents(base_url, &index_doc, &chunk_docs) {
+        let bytes = entry
+            .path_for(target)
+            .and_then(|path| std::fs::read(path).ok());
+        store_cached_sitemap(app_state, entry);
+        if let Some(bytes) = bytes {
+            return Some(bytes);
+        }
+    }
+
+    // Persistence failed (or the read of what we just wrote failed): serve from
+    // the in-memory render so the request still succeeds.
+    match target {
+        SitemapTarget::Index => Some(index_doc.into_bytes()),
+        SitemapTarget::Chunk(id) => chunk_docs
+            .into_iter()
+            .find(|(chunk_id, _)| chunk_id == id)
+            .map(|(_, doc)| doc.into_bytes()),
+    }
+}
+
+/// Render the sitemap into its document strings: the `/sitemap.xml` document and
+/// (when the sitemap is split) one `<urlset>` per chunk id.
+async fn render_documents(app_state: &AppState, base_url: &str) -> (String, Vec<(String, String)>) {
+    let chunks = build_chunks(app_state, base_url).await;
+    match chunks.len() {
+        0 => (render_urlset(&[]), Vec::new()),
+        1 => (render_urlset(&chunks[0].1), Vec::new()),
+        _ => {
+            let index = render_sitemap_index(base_url, &chunks);
+            let chunk_docs = chunks
+                .iter()
+                .map(|(id, urls)| (id.clone(), render_urlset(urls)))
+                .collect();
+            (index, chunk_docs)
+        }
+    }
+}
+
+/// Write the rendered documents to a fresh temporary directory. Returns `None`
+/// if any write fails (the caller falls back to serving from memory).
+fn persist_documents(
+    base_url: &str,
+    index_doc: &str,
+    chunk_docs: &[(String, String)],
+) -> Option<Arc<CachedSitemap>> {
+    let dir = match tempfile::Builder::new()
+        .prefix("tenrankai-sitemap-")
+        .tempdir()
+    {
+        Ok(dir) => dir,
+        Err(e) => {
+            tracing::warn!("Failed to create sitemap temp directory: {}", e);
+            return None;
+        }
+    };
+    if let Err(e) = std::fs::write(dir.path().join("index.xml"), index_doc) {
+        tracing::warn!("Failed to write sitemap index file: {}", e);
+        return None;
+    }
+    let mut chunk_ids = Vec::with_capacity(chunk_docs.len());
+    for (id, doc) in chunk_docs {
+        if let Err(e) = std::fs::write(dir.path().join(format!("{id}.xml")), doc) {
+            tracing::warn!("Failed to write sitemap chunk file {}: {}", id, e);
+            return None;
+        }
+        chunk_ids.push(id.clone());
+    }
+    Some(Arc::new(CachedSitemap {
+        base_url: base_url.to_string(),
+        built_at: Instant::now(),
+        dir,
+        chunk_ids,
+    }))
+}
+
+fn site_base_url(app_state: &AppState) -> Option<String> {
+    let base = app_state.base_url()?.trim_end_matches('/');
+    if base.is_empty() {
+        None
+    } else {
+        Some(base.to_string())
+    }
+}
+
+fn base_url_missing() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        "sitemap unavailable: base_url is not configured for this site\n",
+    )
+        .into_response()
+}
+
+/// Split the site's URLs into `(chunk-id, urls)` pairs. URLs are collected in a
+/// deterministic order so chunk ids stay stable between the sitemap index and
+/// the chunk endpoints.
+async fn build_chunks(app_state: &AppState, base_url: &str) -> Vec<(String, Vec<UrlEntry>)> {
+    let all_urls = collect_urls(app_state, base_url).await;
+    if all_urls.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks: Vec<(String, Vec<UrlEntry>)> = Vec::new();
+    let mut iter = all_urls.into_iter().peekable();
+    let mut part = 0usize;
+    while iter.peek().is_some() {
+        part += 1;
+        let urls: Vec<UrlEntry> = iter.by_ref().take(MAX_URLS_PER_SITEMAP).collect();
+        chunks.push((format!("sitemap-{part}"), urls));
+    }
+    chunks
+}
+
+async fn collect_urls(app_state: &AppState, base_url: &str) -> Vec<UrlEntry> {
+    let mut urls = Vec::new();
+
+    collect_page_urls(app_state, base_url, &mut urls).await;
+
+    let mut gallery_names: Vec<&String> = app_state.galleries().keys().collect();
+    gallery_names.sort();
+    for name in gallery_names {
+        collect_gallery_urls(app_state, base_url, name, &mut urls).await;
+    }
+
+    let mut posts_names: Vec<&String> = app_state.posts_managers().keys().collect();
+    posts_names.sort();
+    for name in posts_names {
+        collect_posts_urls(app_state, base_url, name, &mut urls).await;
+    }
+
+    urls
+}
+
+async fn collect_page_urls(app_state: &AppState, base_url: &str, urls: &mut Vec<UrlEntry>) {
+    let engine = app_state.template_engine();
+
+    if engine.template_exists("pages/index.html.liquid").await {
+        urls.push(UrlEntry::new(format!("{base_url}/")));
+    }
+
+    for route in engine.list_page_routes().await {
+        // Skip internal pages such as `_login/...`.
+        if route.split('/').next().unwrap_or("").starts_with('_') {
+            continue;
+        }
+        urls.push(UrlEntry::new(format!(
+            "{base_url}/{}",
+            encode_path_segments(&route)
+        )));
+    }
+}
+
+async fn collect_gallery_urls(
+    app_state: &AppState,
+    base_url: &str,
+    name: &str,
+    urls: &mut Vec<UrlEntry>,
+) {
+    let Some(gallery) = app_state.galleries().get(name) else {
+        return;
+    };
+    let url_prefix = gallery.get_config().url_prefix.clone();
+
+    let mut folder_urls: Vec<UrlEntry> = Vec::new();
+    let mut image_urls: Vec<UrlEntry> = Vec::new();
+
+    // Breadth-first walk of the (already cached) folder tree. Hidden folders are
+    // omitted from `subdirectories`, so they are never visited.
+    let mut queue: VecDeque<String> = VecDeque::new();
+    queue.push_back(String::new());
+    while let Some(path) = queue.pop_front() {
+        let Some(cached) = gallery.get_cached_folder_data(&path).await else {
+            continue;
+        };
+
+        // Queue children regardless of this folder's visibility: permissions are
+        // resolved per folder, so a private folder may still contain public
+        // children reachable by direct URL.
+        for subdir in &cached.subdirectories {
+            let child = if path.is_empty() {
+                subdir.clone()
+            } else {
+                format!("{path}/{subdir}")
+            };
+            queue.push_back(child);
+        }
+
+        let viewable = matches!(
+            resolve_permissions_for_path(app_state, name, &path, None).await,
+            Ok(perms) if perms.permissions.can_view
+        );
+        if !viewable {
+            continue;
+        }
+
+        let folder_loc = if path.is_empty() {
+            format!("{base_url}{url_prefix}")
+        } else {
+            format!("{base_url}{url_prefix}/{}", encode_path_segments(&path))
+        };
+        folder_urls.push(UrlEntry::new(folder_loc));
+
+        let hidden_images: &[String] = cached
+            .metadata
+            .as_ref()
+            .map(|m| m.config.hidden_images.as_slice())
+            .unwrap_or(&[]);
+
+        // When grouping is active, only primary images appear in the gallery;
+        // mirror that here.
+        let image_paths: Vec<&str> = if cached.image_groups.is_empty() {
+            cached.images.iter().map(String::as_str).collect()
+        } else {
+            cached
+                .image_groups
+                .iter()
+                .map(|group| group.primary_path.as_str())
+                .collect()
+        };
+
+        for image_path in image_paths {
+            let filename = image_path.rsplit('/').next().unwrap_or(image_path);
+            if hidden_images.iter().any(|hidden| hidden == filename) {
+                continue;
+            }
+            let url_id = gallery.build_url_identifier(image_path).await;
+            image_urls.push(UrlEntry::new(format!(
+                "{base_url}{url_prefix}/detail/{url_id}"
+            )));
+        }
+    }
+
+    urls.append(&mut folder_urls);
+    urls.append(&mut image_urls);
+}
+
+async fn collect_posts_urls(
+    app_state: &AppState,
+    base_url: &str,
+    name: &str,
+    urls: &mut Vec<UrlEntry>,
+) {
+    let Some(manager) = app_state.posts_managers().get(name) else {
+        return;
+    };
+    let config = manager.get_config();
+
+    urls.push(UrlEntry::new(format!("{base_url}{}", config.url_prefix)));
+
+    let total_pages = manager.get_total_pages().await;
+    for page in 0..total_pages {
+        for post in manager.get_posts_page(page).await {
+            urls.push(UrlEntry::with_lastmod(
+                format!("{base_url}{}", post.url),
+                post.date.to_rfc3339(),
+            ));
+        }
+    }
+}
+
+/// Percent-encode each `/`-separated segment of a path. Segments never contain
+/// `/`, so re-joining them is lossless.
+fn encode_path_segments(path: &str) -> String {
+    path.split('/')
+        .map(|segment| urlencoding::encode(segment).into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn xml_response(body: Vec<u8>) -> Response {
+    ([(header::CONTENT_TYPE, XML_CONTENT_TYPE)], body).into_response()
+}
+
+fn render_urlset(urls: &[UrlEntry]) -> String {
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(&format!("<urlset xmlns=\"{SITEMAP_XMLNS}\">\n"));
+    for url in urls {
+        out.push_str("  <url><loc>");
+        out.push_str(&xml_escape(&url.loc));
+        out.push_str("</loc>");
+        if let Some(lastmod) = &url.lastmod {
+            out.push_str("<lastmod>");
+            out.push_str(&xml_escape(lastmod));
+            out.push_str("</lastmod>");
+        }
+        out.push_str("</url>\n");
+    }
+    out.push_str("</urlset>\n");
+    out
+}
+
+fn render_sitemap_index(base_url: &str, chunks: &[(String, Vec<UrlEntry>)]) -> String {
+    let mut out = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str(&format!("<sitemapindex xmlns=\"{SITEMAP_XMLNS}\">\n"));
+    for (id, _) in chunks {
+        out.push_str("  <sitemap><loc>");
+        out.push_str(&xml_escape(&format!("{base_url}/sitemap/{id}.xml")));
+        out.push_str("</loc></sitemap>\n");
+    }
+    out.push_str("</sitemapindex>\n");
+    out
+}
+
+fn xml_escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for c in input.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_path_segments_encodes_each_segment() {
+        assert_eq!(encode_path_segments("vacation/2024"), "vacation/2024");
+        assert_eq!(
+            encode_path_segments("My Trips/Rock & Roll"),
+            "My%20Trips/Rock%20%26%20Roll"
+        );
+    }
+
+    #[test]
+    fn xml_escape_escapes_markup() {
+        assert_eq!(xml_escape("a&b<c>"), "a&amp;b&lt;c&gt;");
+        assert_eq!(xml_escape("\"x'y\""), "&quot;x&apos;y&quot;");
+    }
+
+    #[test]
+    fn render_urlset_emits_locs_and_lastmod() {
+        let urls = vec![
+            UrlEntry::new("https://example.com/".to_string()),
+            UrlEntry::with_lastmod(
+                "https://example.com/blog/post".to_string(),
+                "2024-01-02T00:00:00+00:00".to_string(),
+            ),
+        ];
+        let xml = render_urlset(&urls);
+        assert!(xml.contains("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"));
+        assert!(xml.contains("<loc>https://example.com/</loc>"));
+        assert!(xml.contains(
+            "<loc>https://example.com/blog/post</loc><lastmod>2024-01-02T00:00:00+00:00</lastmod>"
+        ));
+        assert!(xml.trim_end().ends_with("</urlset>"));
+    }
+
+    #[test]
+    fn render_sitemap_index_lists_chunks() {
+        let chunks = vec![
+            ("sitemap-1".to_string(), Vec::new()),
+            ("sitemap-2".to_string(), Vec::new()),
+        ];
+        let xml = render_sitemap_index("https://example.com", &chunks);
+        assert!(xml.contains("<sitemapindex"));
+        assert!(xml.contains("<loc>https://example.com/sitemap/sitemap-1.xml</loc>"));
+        assert!(xml.contains("<loc>https://example.com/sitemap/sitemap-2.xml</loc>"));
+    }
+}

--- a/tenrankai/src/templating.rs
+++ b/tenrankai/src/templating.rs
@@ -10,7 +10,7 @@ use axum::{
 use liquid::Parser;
 use liquid_core::{Filter, FilterReflection, ParseFilter, Runtime, Value, ValueView};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::Arc,
     time::{Duration, Instant, SystemTime},
 };
@@ -240,6 +240,40 @@ impl TemplateEngine {
             }
         }
         false
+    }
+
+    /// List the relative route paths backed by `pages/*.html.liquid` templates,
+    /// excluding the homepage (`index`) and the error page (`404`).
+    ///
+    /// Paths are returned without the `pages/` prefix or `.html.liquid` suffix,
+    /// e.g. `about` or `legal/privacy`. Results are de-duplicated across all
+    /// template storage backends and sorted for deterministic output.
+    pub async fn list_page_routes(&self) -> Vec<String> {
+        let mut seen = HashSet::new();
+        let mut routes = Vec::new();
+        for storage in &self.storages {
+            let entries = match storage.list_recursive("pages").await {
+                Ok(entries) => entries,
+                Err(_) => continue,
+            };
+            for entry in entries {
+                if entry.is_dir {
+                    continue;
+                }
+                let rel = entry.path.replace('\\', "/");
+                let Some(rel) = rel.strip_suffix(".html.liquid") else {
+                    continue;
+                };
+                if rel == "index" || rel == "404" {
+                    continue;
+                }
+                if seen.insert(rel.to_string()) {
+                    routes.push(rel.to_string());
+                }
+            }
+        }
+        routes.sort();
+        routes
     }
 
     pub fn set_static_handler(&mut self, handler: crate::static_files::StaticFileHandler) {

--- a/tests/sitemap_integration.rs
+++ b/tests/sitemap_integration.rs
@@ -1,0 +1,175 @@
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+use tenrankai::{
+    GallerySystemConfig, ImageIndexingMode, PostsSystemConfig, StaticConfig, TemplateConfig,
+    create_app, site::SiteConfig,
+};
+
+fn write_image(path: &Path) {
+    let img = image::ImageBuffer::from_fn(64, 64, |x, y| {
+        image::Rgb([(x * 4) as u8, (y * 4) as u8, 128u8])
+    });
+    img.save(path).unwrap();
+}
+
+async fn setup_test_server() -> (TempDir, TestServer) {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Reuse the real templates directory so the dynamic pages (`about`,
+    // `contact`, ...) are discoverable. CARGO_MANIFEST_DIR is the tenrankai
+    // package directory; the templates live at the workspace root.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+    let templates_dir = workspace_root.join("templates");
+
+    let static_dir = temp_dir.path().join("static");
+    let photos_dir = temp_dir.path().join("photos");
+    let cache_dir = temp_dir.path().join("cache");
+    let posts_dir = temp_dir.path().join("posts");
+    fs::create_dir_all(&static_dir).unwrap();
+    fs::create_dir_all(&photos_dir).unwrap();
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::create_dir_all(&posts_dir).unwrap();
+
+    // Images directly in the gallery root.
+    write_image(&photos_dir.join("alpha.jpg"));
+    write_image(&photos_dir.join("beta.jpg"));
+
+    // A publicly visible subfolder.
+    let vacation_dir = photos_dir.join("vacation");
+    fs::create_dir_all(&vacation_dir).unwrap();
+    write_image(&vacation_dir.join("gamma.jpg"));
+
+    // A subfolder restricted to authenticated users only.
+    let secret_dir = photos_dir.join("secret");
+    fs::create_dir_all(&secret_dir).unwrap();
+    fs::write(
+        secret_dir.join("_folder.md"),
+        "+++\n[permissions]\npublic_role = \"none\"\n+++\nSecret stuff\n",
+    )
+    .unwrap();
+    write_image(&secret_dir.join("delta.jpg"));
+
+    // A blog post.
+    fs::write(
+        posts_dir.join("hello-world.md"),
+        "+++\ntitle = \"Hello World\"\nsummary = \"First post\"\ndate = \"2024-03-04\"\n+++\n\n# Hello\n",
+    )
+    .unwrap();
+
+    // Unique per test so the process-wide sitemap cache never bleeds between
+    // tests running in parallel.
+    let site_name = format!(
+        "sitemap-test-{}",
+        temp_dir.path().file_name().unwrap().to_string_lossy()
+    );
+
+    let config = SiteConfig {
+        name: site_name,
+        base_url: Some("https://example.com".to_string()),
+        cookie_secret: "test-cookie-secret".to_string(),
+        templates: TemplateConfig {
+            directories: vec![templates_dir.to_string_lossy().to_string()],
+        },
+        static_files: StaticConfig {
+            directories: vec![static_dir.to_string_lossy().to_string()],
+            use_redirects: false,
+        },
+        galleries: Some(vec![GallerySystemConfig {
+            name: "main".to_string(),
+            source_directory: photos_dir.to_string_lossy().to_string(),
+            cache_directory: cache_dir.to_string_lossy().to_string(),
+            gallery_template: "gallery.html.liquid".to_string(),
+            image_detail_template: "image_detail.html.liquid".to_string(),
+            image_indexing: ImageIndexingMode::Filename,
+            ..Default::default()
+        }]),
+        posts: Some(vec![PostsSystemConfig {
+            name: "blog".to_string(),
+            source_directory: posts_dir.to_string_lossy().to_string(),
+            url_prefix: "/blog".to_string(),
+            index_template: "modules/posts_index.html.liquid".to_string(),
+            post_template: "modules/post_detail.html.liquid".to_string(),
+            posts_per_page: 10,
+            refresh_interval_minutes: None,
+        }]),
+        user_database: None,
+        email: None,
+        config_storage: None,
+        site_admins: Vec::new(),
+        hosted_mode: false,
+    };
+
+    let app = create_app(config, None).await;
+    let server = TestServer::new(app.into_make_service());
+    (temp_dir, server)
+}
+
+#[tokio::test]
+async fn sitemap_lists_public_resources() {
+    let (_temp_dir, server) = setup_test_server().await;
+
+    let response = server.get("/sitemap.xml").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert!(
+        response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("application/xml")
+    );
+
+    let xml = response.text();
+    assert!(xml.contains("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"));
+
+    // Static pages discovered from templates/pages/.
+    assert!(xml.contains("<loc>https://example.com/</loc>"));
+    assert!(xml.contains("<loc>https://example.com/about</loc>"));
+    assert!(xml.contains("<loc>https://example.com/contact</loc>"));
+
+    // Gallery root and the publicly visible subfolder.
+    assert!(xml.contains("<loc>https://example.com/gallery</loc>"));
+    assert!(xml.contains("<loc>https://example.com/gallery/vacation</loc>"));
+
+    // Image detail pages.
+    assert!(xml.contains("https://example.com/gallery/detail/"));
+
+    // Posts index and the post itself (with its publish date as lastmod).
+    assert!(xml.contains("<loc>https://example.com/blog</loc>"));
+    assert!(xml.contains("<loc>https://example.com/blog/hello-world</loc>"));
+    assert!(xml.contains("<lastmod>2024-03-04T00:00:00+00:00</lastmod>"));
+
+    // The restricted folder and its images must not be exposed.
+    assert!(!xml.contains("/gallery/secret"));
+    assert!(!xml.contains("delta.jpg"));
+}
+
+#[tokio::test]
+async fn robots_txt_references_sitemap() {
+    let (_temp_dir, server) = setup_test_server().await;
+
+    let response = server.get("/robots.txt").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert!(
+        response
+            .text()
+            .contains("Sitemap: https://example.com/sitemap.xml")
+    );
+}
+
+#[tokio::test]
+async fn sitemap_chunk_is_not_found_for_small_site() {
+    let (_temp_dir, server) = setup_test_server().await;
+
+    // A small site serves a single <urlset> at /sitemap.xml, so no chunk files
+    // exist.
+    let response = server.get("/sitemap/pages-1.xml").await;
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+
+    let response = server.get("/sitemap/nope.xml").await;
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Adds an automatically-generated `sitemap.xml`, per site, covering all publicly visible resources.

- **`GET /sitemap.xml`** — lists, for the request's resolved site:
  - static pages (`pages/*.html.liquid`, e.g. `/`, `/about`, `/contact`) — internal `_…` pages skipped
  - every publicly viewable gallery folder and image detail page (`/<prefix>`, `/<prefix>/<folder>`, `/<prefix>/detail/<id>`)
  - posts index + each post (`/<prefix>`, `/<prefix>/<slug>`), with the post's date as `<lastmod>`
- **Permissions are honoured** — a folder whose `_folder.md` sets `public_role = "none"` (or a gallery with no public role) is omitted along with its images; `hidden` folders are never listed; a private parent doesn't hide its (independently-public) children.
- **Large sites** — when the URL count exceeds the 50,000-per-file protocol limit, `/sitemap.xml` becomes a `<sitemapindex>` pointing at `/sitemap/sitemap-1.xml`, `/sitemap/sitemap-2.xml`, … (each ≤ 45k URLs). Small sites get a single `<urlset>` and the chunk routes 404.
- **Cached via temp files** — the rendered XML is written once to a per-site temporary directory (`tempfile::TempDir`) and served from there for up to 5 minutes, so crawler traffic doesn't re-walk the gallery tree and the (potentially large) documents stay out of resident memory. The temp directory is auto-removed when the cache entry expires/is replaced. If the temp directory can't be written, the freshly rendered document is served directly (uncached) so the endpoint never 500s on that path. Chunk lookups are restricted to known chunk ids.
- **`robots.txt`** now emits `Sitemap: <base_url>/sitemap.xml` when `base_url` is configured. The sitemap endpoint itself returns 404 when `base_url` isn't set, since sitemaps require absolute URLs.

## Changes

- `tenrankai/src/sitemap.rs` (new) — handlers, URL collection, chunking, XML rendering, temp-file cache; unit tests
- `tenrankai/src/templating.rs` — new `TemplateEngine::list_page_routes()` to enumerate dynamic page templates
- `tenrankai/src/lib.rs` — `pub mod sitemap;` + `/sitemap.xml` and `/sitemap/{file}` routes
- `tenrankai/src/robots.rs` — advertise the sitemap when `base_url` is set
- `tenrankai/Cargo.toml` — move `tempfile` from dev-deps to deps; register the `sitemap_integration` test
- `tests/sitemap_integration.rs` (new) — integration tests (public resources listed, private folders excluded, robots.txt references the sitemap, chunk routes 404 on small sites)
- `CHANGELOG.md`, `README.md` — docs

## Testing

- `cargo fmt --check` — clean
- `cargo clippy --no-default-features -p tenrankai -- -D warnings` — clean
- `cargo test --no-default-features -p tenrankai` — lib tests pass; new sitemap unit + integration tests pass; touched integration suites (gallery, posts, template, cascading static dirs, admin/hidden-images, asset-url, null-email) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)