### PR TITLE
chore(deps): Bump hmac to 0.13 and sha2 to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1374,7 +1380,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1425,6 +1431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -4947,7 +4954,8 @@ dependencies = [
  "flate2",
  "fnv",
  "futures",
- "hmac 0.12.1",
+ "hex",
+ "hmac 0.13.0",
  "httpdate",
  "ico",
  "image",
@@ -4970,7 +4978,7 @@ dependencies = [
  "rgb",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "tempfile",
  "tenrankai-config-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,9 @@ quick-xml = "0.40"
 pulldown-cmark = "0.13"
 
 # Crypto and encoding
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
+hex = "0.4"
 flate2 = "1.1"
 
 # CLI

--- a/tenrankai/Cargo.toml
+++ b/tenrankai/Cargo.toml
@@ -96,6 +96,7 @@ pulldown-cmark.workspace = true
 base64.workspace = true
 hmac.workspace = true
 sha2.workspace = true
+hex.workspace = true
 flate2.workspace = true
 
 # CLI

--- a/tenrankai/src/api.rs
+++ b/tenrankai/src/api.rs
@@ -10,7 +10,7 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 use base64::{Engine, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use serde::{Deserialize, Serialize};
 use serde_json;
 use sha2::Sha256;

--- a/tenrankai/src/gallery/cache.rs
+++ b/tenrankai/src/gallery/cache.rs
@@ -32,7 +32,7 @@ pub fn generate_tile_cache_filename(
     let mut hasher = Sha256::new();
     hasher.update(path);
     hasher.update(&cache_key);
-    let hash = format!("{:x}", hasher.finalize());
+    let hash = hex::encode(hasher.finalize());
 
     // Make the filename somewhat readable
     format!(
@@ -247,7 +247,7 @@ impl Gallery {
         let mut hasher = Sha256::new();
         hasher.update(path);
         hasher.update(size);
-        format!("{:x}", hasher.finalize())
+        hex::encode(hasher.finalize())
     }
 
     /// Generate a cache key for regular images with size, format, and watermark status
@@ -323,7 +323,7 @@ impl Gallery {
             if encoded_path.len() > 40 {
                 let mut hasher = Sha256::new();
                 hasher.update(gallery_path);
-                let hash_suffix = &format!("{:x}", hasher.finalize())[..8];
+                let hash_suffix = &hex::encode(hasher.finalize())[..8];
                 format!("{}_{}", &encoded_path[..32], hash_suffix)
             } else {
                 encoded_path

--- a/tenrankai/src/gallery/mod.rs
+++ b/tenrankai/src/gallery/mod.rs
@@ -211,7 +211,7 @@ impl Gallery {
         hasher.update(config.padding.to_le_bytes());
         hasher.update([config.adaptive as u8]);
 
-        let hash = format!("{:x}", hasher.finalize());
+        let hash = hex::encode(hasher.finalize());
         Some(hash[..8].to_string())
     }
 

--- a/tenrankai/src/theme/mod.rs
+++ b/tenrankai/src/theme/mod.rs
@@ -140,12 +140,6 @@ pub fn compute_theme_etag(css: &str) -> String {
     format!("\"{}\"", hex::encode(&hash[..8]))
 }
 
-mod hex {
-    pub fn encode(bytes: &[u8]) -> String {
-        bytes.iter().map(|b| format!("{:02x}", b)).collect()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/admin_and_hidden_images_tests.rs
+++ b/tests/admin_and_hidden_images_tests.rs
@@ -1,7 +1,7 @@
 use axum::http::{HeaderValue, StatusCode, header};
 use axum_test::TestServer;
 use base64::{Engine, engine::general_purpose};
-use hmac::{Hmac, Mac};
+use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 use tempfile::TempDir;
 use tenrankai::{


### PR DESCRIPTION
Combines the two Dependabot bumps that can only land together, plus the API migration they require.

## Why combined
`hmac` 0.13 and `sha2` 0.11 both moved to the RustCrypto `digest` 0.11 ecosystem. `hmac` 0.13's `Hmac<D>` requires `D: EagerHash`, which `sha2` only provides from 0.11 onward — so bumping either crate alone fails to compile. That's why the individual Dependabot PRs were red:
- Closes #185 (hmac 0.12 → 0.13)
- Closes #184 (sha2 0.10 → 0.11)

## API changes handled
- `Mac::new_from_slice` now lives on the `KeyInit` trait — imported where HMAC instances are built (`api.rs` and the admin integration test).
- `digest` 0.11's `finalize()` output no longer implements `LowerHex`, so `format!("{:x}", ..)` no longer compiles. Switched the SHA-256 formatting sites to `hex::encode`, which yields **identical** lowercase hex — cache keys and ETags are byte-for-byte unchanged, so no cache invalidation. Also dropped the now-redundant hand-rolled hex helper in `theme/mod.rs`.

## Verification
- `cargo build` (AVIF) and `cargo build --no-default-features` both clean
- `cargo clippy --workspace --no-default-features -- -D warnings` clean; `cargo fmt --check` clean
- 235 lib unit tests pass; 30 admin/HMAC integration tests pass (exercises cookie signing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)