### PR TITLE
chore(deps): Bump quinn-proto and memmap2 to fix security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3072,9 +3072,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3723,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4156,7 +4156,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4213,7 +4213,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4932,7 +4932,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6060,7 +6060,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes the failing **Security Audit** CI job (`cargo audit`).

The daily scheduled audit has been failing since 2026-06-23 due to two RustSec advisories against transitive dependencies:

| Crate | From → To | Advisory | Severity |
|-------|-----------|----------|----------|
| `quinn-proto` | 0.11.14 → 0.11.15 | [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) — remote memory exhaustion from unbounded out-of-order stream reassembly | High (7.5) — **failed CI** |
| `memmap2` | 0.9.10 → 0.9.11 | [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186) — unchecked pointer offset (unsound) | Warning |

`quinn-proto` is pulled in transitively via `reqwest` (HTTP/3); `memmap2` via `resvg` → `usvg` → `fontdb`. Both bumps are semver-compatible patch updates. The diff also includes incidental `windows-sys` unification that `cargo update` applied (Windows-only, benign).

## Verification

`cargo audit` now exits 0 with no vulnerabilities or warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)