### PR TITLE
ci: fix macOS SecureTransport git-fetch failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Fetch git dependencies (libavif/libavif-sys) with the system git CLI instead
+  # of libgit2. Avoids intermittent macOS "SecureTransport error: connection
+  # closed via error" failures from the libgit2 fetch backend.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Fetch git dependencies (libavif/libavif-sys) with the system git CLI instead
+  # of libgit2. Avoids intermittent macOS "SecureTransport error: connection
+  # closed via error" failures from the libgit2 fetch backend.
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
 
 jobs:
   create-release:


### PR DESCRIPTION
## Problem

The macOS CI job (`Test (macos-latest)`) has been failing — reported at the clippy step, but the real failure is a network error while cargo fetches the `libavif`/`libavif-sys` **git** dependencies:

```
warning: spurious network error (3 tries remaining): SecureTransport error: connection closed via error; class=Net (12)
error: failed to get `libavif` as a dependency of package `tenrankai v0.2.0`
  SecureTransport error: connection closed via error; class=Net (12)
```

`libavif`/`libavif-sys` are git deps (`Cargo.toml:72-73`). cargo's default git transport is libgit2 over macOS SecureTransport, which intermittently drops the connection. Only macOS is affected:

- **Windows** builds `--no-default-features`, so it never pulls these git deps.
- **Ubuntu** uses a TLS backend that doesn't exhibit the flake.

## Fix

Set `CARGO_NET_GIT_FETCH_WITH_CLI=true` in the global `env` block of `ci.yml` and `release.yml`, so cargo fetches git deps via the system `git` CLI (reliable TLS stack) instead of libgit2. It's a no-op on Ubuntu/Windows and only changes the git fetch transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)