### PR TITLE
fix(deps): Bump quick-xml to 0.41 to fix RUSTSEC-2026-0194/0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,9 +3598,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rgb = "0.8"
 
 # EXIF and metadata
 rexif = "0.7"
-quick-xml = "0.40"
+quick-xml = "0.41"
 
 # Markdown
 pulldown-cmark = "0.13"


### PR DESCRIPTION
## Problem

The daily **Security Audit** CI has been failing since 2026-07-03 (last green run 2026-07-02). `cargo audit` reports two vulnerabilities in **quick-xml 0.40.1**:

| Advisory | Title | Fix |
|----------|-------|-----|
| [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) | Quadratic run time when checking a start tag for duplicate attribute names | `>=0.41.0` |
| [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) | Unbounded namespace-declaration allocation in `NsReader` enabling memory-exhaustion DoS | `>=0.41.0` |

`quick-xml` is a direct workspace dependency used in:
- `tenrankai/src/gallery/metadata_sources.rs` (XMP metadata parsing)
- `tenrankai-image/src/formats/heif.rs` (HDR gain-map XMP parsing, behind `heif` feature)

## Fix

Bump the workspace `quick-xml` dependency `0.40` → `0.41`. The 0.41 release is API-compatible with our usage (`Reader::from_str`, `config_mut().trim_text`, `read_event_into`, `Event` matching), so **no source changes were required**.

## Verification

- `cargo check --no-default-features` ✅
- `cargo check -p tenrankai-image --features heif` ✅
- `cargo clippy -p tenrankai -p tenrankai-image` ✅ (no new warnings)
- XMP parsing unit tests pass (5/5 in `metadata_sources`)
- `cargo audit` locally now **exits 0** — 0 vulnerabilities; the remaining `anyhow`/`ttf-parser` items are allowed warnings (unsound/unmaintained), not errors
- Lockfile change is limited to the single `quick-xml` version bump (2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)