### PR TITLE
Make default templates generic with config-driven site identity

### DIFF
--- a/templates/modules/gallery.html.liquid
+++ b/templates/modules/gallery.html.liquid
@@ -3,7 +3,8 @@
 {% else %}
     {% assign page_title = "Gallery" %}
 {% endif %}
-{% assign meta_description = folder_description | default: "Browse the photo gallery on theatr.us" | strip_html | truncate: 160 %}
+{% assign default_gallery_description = "Browse the photo gallery on " | append: site_title %}
+{% assign meta_description = folder_description | default: default_gallery_description | strip_html | truncate: 160 %}
 {% assign page_css = "gallery-filters.css,editor.css,gallery-manage.css,share-modal.css" | split: "," %}
 {% include "_header.html.liquid" %}
 

--- a/templates/modules/image_detail.html.liquid
+++ b/templates/modules/image_detail.html.liquid
@@ -3,7 +3,8 @@
 {% if image.user_metadata.ai_alt_text %}
     {% assign meta_description = image.user_metadata.ai_alt_text | strip_html | truncate: 160 %}
 {% else %}
-    {% assign meta_description = image.description | default: "View this image on theatr.us gallery" | strip_html | truncate: 160 %}
+    {% assign default_image_description = "View this image on " | append: site_title | append: " gallery" %}
+        {% assign meta_description = image.description | default: default_image_description | strip_html | truncate: 160 %}
 {% endif %}
 
 {% comment %} Open Graph tags for image {% endcomment %}

--- a/templates/pages/404.html.liquid
+++ b/templates/pages/404.html.liquid
@@ -1,5 +1,5 @@
 {% assign page_title = "Page Not Found" %}
-{% assign meta_description = "The requested page could not be found on theatr.us" %}
+{% assign meta_description = "The requested page could not be found" %}
 {% include "_header.html.liquid" %}
 
 <div class="container">

--- a/templates/pages/about.html.liquid
+++ b/templates/pages/about.html.liquid
@@ -1,20 +1,17 @@
 {% assign page_title = "About" %}
-{% assign meta_description = "Learn more about theatr.us and the person behind the photography" %}
+{% assign meta_description = "About this gallery" %}
 {% include "_header.html.liquid" %}
 
 <div class="container">
-    <h2>About theatr.us</h2> 
-    
-    <p>Hi, my name is Yann. I nominally do software and have done that since the
-    late 1990s. I'm really good at embedded systems, Rust, C, C++, distributed
-    systems, infrastructure, and have worked at various places including
-    Twitter, Lyft, and Airbnb. 
+    <h2>About {{ site_title }}</h2>
 
-    <p>I'm an expert in Observability and Reliability systems.
-    <p>And I like doing hardware projects, software projects, fish (reef and fresh water), pictures (of things), and space (and pictures of space). And more importantly, the intersection of all of those.
-    
-    <p>Need to get in contact? Try the Contact tab. 
-    <!-- Example of using the gallery preview component with custom parameters -->
+    <p>Welcome to {{ site_title }}, a photo gallery built with
+    <a href="https://github.com/theatrus/tenrankai">tenrankai</a>.</p>
+
+    <p>Edit this page to introduce yourself and your work.</p>
+
+    <p>Need to get in contact? Try the Contact tab.</p>
+
     <div style="margin-top: 3rem;">
         {% include "_gallery_preview.html.liquid" gallery_name: "main", gallery_url: "/gallery" %}
     </div>

--- a/templates/pages/contact.html.liquid
+++ b/templates/pages/contact.html.liquid
@@ -1,23 +1,18 @@
 {% assign page_title = "Contact" %}
-{% assign meta_description = "Get in touch with theatr.us" %}
+{% assign meta_description = "Get in touch" %}
 {% assign page_css = "contact.css" | split: "," %}
 {% include "_header.html.liquid" %}
 
 <div class="container container-sm contact-container">
     <h2>Contact</h2>
-    
+
     <div class="contact-content">
         <p>Get in touch through the following channels:</p>
-        
+
         <div class="contact-methods">
             <div class="contact-item card">
                 <h3>Email</h3>
-                <p><a href="mailto:blog@theatr.us">blog@theatr.us</a></p>
-            </div>
-            
-            <div class="contact-item card">
-                <h3>LinkedIn</h3>
-                <p><a href="https://www.linkedin.com/in/yannramin/" target="_blank" rel="noopener noreferrer">linkedin.com/in/yannramin</a></p>
+                <p><a href="mailto:hello@example.com">hello@example.com</a></p>
             </div>
         </div>
     </div>

--- a/templates/pages/index.html.liquid
+++ b/templates/pages/index.html.liquid
@@ -1,36 +1,13 @@
 {% assign page_title = "Home" %}
-{% assign meta_description = "theatr.us - A gallery of photographs and visual stories" %}
+{% assign meta_description = "A photo gallery powered by tenrankai" %}
 {% assign page_css = "home.css" | split: "," %}
 {% include "_header.html.liquid" %}
 
 <div class="container container-md home-container">
-    <h2>Welcome to theatr.us</h2> <p>Do you like pictures? I do. Here are some
-    of them. </p>
-    
-    <!-- Gallery preview will be available when component data is loaded -->
+    <h2>Welcome to {{ site_title }}</h2>
+    <p>A collection of photographs. Browse the gallery below.</p>
+
     {% include "_gallery_preview.html.liquid" gallery_name: "main", gallery_url: "/gallery" %}
-    
-    <!--
-    <section class="about-section">
-        <h3>About</h3>
-        <p>This gallery showcases a collection of photography work spanning multiple years and subjects. Each image tells a story, captured with attention to composition, lighting, and technical excellence.</p>
-        
-        <div class="feature-grid">
-            <div class="feature">
-                <h4>Professional Quality</h4>
-                <p>High-resolution images with detailed EXIF data and technical information.</p>
-            </div>
-            <div class="feature">
-                <h4>Organized Collections</h4>
-                <p>Carefully curated folders with descriptions and context for each series.</p>
-            </div>
-            <div class="feature">
-                <h4>Technical Excellence</h4>
-                <p>Built with modern web technologies for fast loading and responsive design.</p>
-            </div>
-        </div>
-    </section>
-    -->
 </div>
 
 {% include "_footer.html.liquid" %}

--- a/templates/partials/_footer.html.liquid
+++ b/templates/partials/_footer.html.liquid
@@ -1,6 +1,6 @@
     </main>
     <footer>
-        <p>&copy; {{ current_year }} Yann Ramin. All rights reserved.</p>
+        <p>&copy; {{ current_year }} {{ copyright_holder }}. All rights reserved.</p>
         <p>Powered by <a href="https://github.com/theatrus/tenrankai">tenrankai</a></p>
     </footer>
     

--- a/templates/partials/_header.html.liquid
+++ b/templates/partials/_header.html.liquid
@@ -6,7 +6,7 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <title>{% if page_title %}{{ page_title }} - {% endif %}theatr.us</title>
+    <title>{% if page_title %}{{ page_title }} - {% endif %}{{ site_title }}</title>
     
     {% if meta_description %}
     <meta name="description" content="{{ meta_description }}">
@@ -32,7 +32,7 @@
     {% if og_url %}
     <meta property="og:url" content="{{ og_url }}">
     {% endif %}
-    <meta property="og:site_name" content="theatr.us">
+    <meta property="og:site_name" content="{{ site_title }}">
     
     {% comment %} Twitter Card meta tags {% endcomment %}
     <meta name="twitter:card" content="{% if twitter_card_type %}{{ twitter_card_type }}{% else %}summary_large_image{% endif %}">
@@ -80,7 +80,7 @@
 <body>
     <header>
         <nav>
-            <h1><a href="/">theatr.us</a></h1>
+            <h1><a href="/">{{ site_title }}</a></h1>
             <ul>
                 <li><a href="/gallery">Gallery</a></li>
                 <li><a href="/about">About</a></li>

--- a/tenrankai-config-storage/src/file_dir.rs
+++ b/tenrankai-config-storage/src/file_dir.rs
@@ -609,6 +609,8 @@ mod tests {
             cache_prefix: Some("/var/cache/sites/default".to_string()),
             email: None,
             theme: None,
+            site_title: None,
+            copyright_holder: None,
         };
 
         storage

--- a/tenrankai-config-storage/src/types.rs
+++ b/tenrankai-config-storage/src/types.rs
@@ -262,6 +262,16 @@ pub struct StoredSiteConfig {
     /// Theme customization configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub theme: Option<StoredThemeConfig>,
+
+    /// Display title for the site, used in the page `<title>`, header heading,
+    /// and Open Graph `site_name`. Falls back to the app name when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub site_title: Option<String>,
+
+    /// Copyright holder shown in the site footer.
+    /// Falls back to the site title when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copyright_holder: Option<String>,
 }
 
 /// Per-site email sender configuration

--- a/tenrankai-config-storage/src/url.rs
+++ b/tenrankai-config-storage/src/url.rs
@@ -166,7 +166,7 @@ mod tests {
     fn test_parse_relative_path() {
         let url = ConfigStorageUrl::parse("config.d").unwrap();
         assert!(
-            matches!(url, ConfigStorageUrl::FileDir { path } if path == PathBuf::from("config.d"))
+            matches!(url, ConfigStorageUrl::FileDir { path } if path == std::path::Path::new("config.d"))
         );
     }
 
@@ -174,7 +174,7 @@ mod tests {
     fn test_parse_absolute_path() {
         let url = ConfigStorageUrl::parse("/var/lib/tenrankai/config.d").unwrap();
         assert!(
-            matches!(url, ConfigStorageUrl::FileDir { path } if path == PathBuf::from("/var/lib/tenrankai/config.d"))
+            matches!(url, ConfigStorageUrl::FileDir { path } if path == std::path::Path::new("/var/lib/tenrankai/config.d"))
         );
     }
 
@@ -182,7 +182,7 @@ mod tests {
     fn test_parse_file_url() {
         let url = ConfigStorageUrl::parse("file:///var/lib/config.d").unwrap();
         assert!(
-            matches!(url, ConfigStorageUrl::FileDir { path } if path == PathBuf::from("/var/lib/config.d"))
+            matches!(url, ConfigStorageUrl::FileDir { path } if path == std::path::Path::new("/var/lib/config.d"))
         );
     }
 

--- a/tenrankai/src/api.rs
+++ b/tenrankai/src/api.rs
@@ -2440,7 +2440,7 @@ roles = ["viewer"]
         let static_handler = crate::static_files::StaticFileHandler::from_paths(static_paths);
 
         // Convert template directories to storage backends
-        let template_storages: Vec<crate::storage::DynStorage> = vec!["templates"]
+        let template_storages: Vec<crate::storage::DynStorage> = ["templates"]
             .iter()
             .map(|dir| {
                 Arc::new(crate::storage::FilesystemStorage::new(

--- a/tenrankai/src/commands/config.rs
+++ b/tenrankai/src/commands/config.rs
@@ -192,6 +192,8 @@ pub async fn handle_add_site_command(
         cache_prefix: None,
         email: None,
         theme: None,
+        site_title: None,
+        copyright_holder: None,
     };
 
     storage.set_site_config(name, &site_config, "cli").await?;

--- a/tenrankai/src/config/storage_loader.rs
+++ b/tenrankai/src/config/storage_loader.rs
@@ -187,6 +187,8 @@ impl ConfigStorageLoader {
             config_storage: None, // Will be set by the startup code
             site_admins,
             hosted_mode: false, // Will be set by the startup code from AppConfig
+            site_title: stored.site_title,
+            copyright_holder: stored.copyright_holder,
         })
     }
 

--- a/tenrankai/src/gallery/grouping.rs
+++ b/tenrankai/src/gallery/grouping.rs
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_group_files_simple() {
-        let entries = vec![
+        let entries = [
             ("photos/IMG_0001.jpg", None, 1000u64),
             ("photos/IMG_0001.dng", None, 5000u64),
         ];
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn test_group_files_with_versions() {
-        let entries = vec![
+        let entries = [
             ("photos/IMG_0001.jpg", None, 1000u64),
             ("photos/IMG_0001_v1.jpg", None, 1100u64),
             ("photos/IMG_0001_v2.jpg", None, 1200u64),
@@ -400,7 +400,7 @@ mod tests {
         let now = SystemTime::now();
         let older = now - std::time::Duration::from_secs(3600);
 
-        let entries = vec![
+        let entries = [
             ("photos/IMG_0001.jpg", Some(older), 1000u64),
             ("photos/__versions/IMG_0001.jpg", Some(now), 1100u64),
         ];

--- a/tenrankai/src/gallery/indexing.rs
+++ b/tenrankai/src/gallery/indexing.rs
@@ -370,7 +370,7 @@ mod tests {
         assert!(folder_id.starts_with("folder/"));
         let id_part = folder_id.strip_prefix("folder/").unwrap();
         assert_eq!(id_part.len(), 6);
-        assert_eq!(indexer.get_path(&folder_id), Some("folder/image.jpg"));
+        assert_eq!(indexer.get_path(folder_id), Some("folder/image.jpg"));
     }
 
     #[test]

--- a/tenrankai/src/permissions/extractors.rs
+++ b/tenrankai/src/permissions/extractors.rs
@@ -412,10 +412,12 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_permissions_for_path_public() {
         // Create minimal app state for testing
-        let mut gallery_config = crate::GallerySystemConfig::default();
-        gallery_config.name = "test".to_string();
-        gallery_config.source_directory = ".".to_string();
-        gallery_config.cache_directory = ".".to_string();
+        let gallery_config = crate::GallerySystemConfig {
+            name: "test".to_string(),
+            source_directory: ".".to_string(),
+            cache_directory: ".".to_string(),
+            ..Default::default()
+        };
 
         let source_storage = create_test_storage(&gallery_config.source_directory);
         let cache_storage = create_test_storage(&gallery_config.cache_directory);

--- a/tenrankai/src/permissions/tests.rs
+++ b/tenrankai/src/permissions/tests.rs
@@ -72,15 +72,16 @@ mod scenario_tests {
             },
         );
 
-        let mut user_roles = Vec::new();
-        user_roles.push(UserRole {
-            username: "alice".to_string(),
-            roles: vec!["client".to_string()],
-        });
-        user_roles.push(UserRole {
-            username: "bob".to_string(),
-            roles: vec!["photographer".to_string()],
-        });
+        let user_roles = vec![
+            UserRole {
+                username: "alice".to_string(),
+                roles: vec!["client".to_string()],
+            },
+            UserRole {
+                username: "bob".to_string(),
+                roles: vec!["photographer".to_string()],
+            },
+        ];
 
         gallery_config.permissions = PermissionConfig {
             site_admins: Vec::new(),
@@ -175,19 +176,20 @@ mod scenario_tests {
             },
         );
 
-        let mut user_roles = Vec::new();
-        user_roles.push(UserRole {
-            username: "mom".to_string(),
-            roles: vec!["family".to_string()],
-        });
-        user_roles.push(UserRole {
-            username: "uncle_joe".to_string(),
-            roles: vec!["extended_family".to_string()],
-        });
-        user_roles.push(UserRole {
-            username: "timmy".to_string(),
-            roles: vec!["kids".to_string()],
-        });
+        let user_roles = vec![
+            UserRole {
+                username: "mom".to_string(),
+                roles: vec!["family".to_string()],
+            },
+            UserRole {
+                username: "uncle_joe".to_string(),
+                roles: vec!["extended_family".to_string()],
+            },
+            UserRole {
+                username: "timmy".to_string(),
+                roles: vec!["kids".to_string()],
+            },
+        ];
 
         gallery_config.permissions = PermissionConfig {
             site_admins: Vec::new(),
@@ -299,19 +301,20 @@ mod scenario_tests {
             },
         );
 
-        let mut user_roles = Vec::new();
-        user_roles.push(UserRole {
-            username: "alice".to_string(),
-            roles: vec!["team_member".to_string()],
-        });
-        user_roles.push(UserRole {
-            username: "bob".to_string(),
-            roles: vec!["team_lead".to_string()],
-        });
-        user_roles.push(UserRole {
-            username: "carol".to_string(),
-            roles: vec!["admin".to_string()],
-        });
+        let user_roles = vec![
+            UserRole {
+                username: "alice".to_string(),
+                roles: vec!["team_member".to_string()],
+            },
+            UserRole {
+                username: "bob".to_string(),
+                roles: vec!["team_lead".to_string()],
+            },
+            UserRole {
+                username: "carol".to_string(),
+                roles: vec!["admin".to_string()],
+            },
+        ];
 
         gallery_config.permissions = PermissionConfig {
             site_admins: Vec::new(),
@@ -429,11 +432,10 @@ mod scenario_tests {
             },
         );
 
-        let mut folder_user_roles = Vec::new();
-        folder_user_roles.push(UserRole {
+        let folder_user_roles = vec![UserRole {
             username: "trusted_friend".to_string(),
             roles: vec!["trusted".to_string()],
-        });
+        }];
 
         folder_config.permissions = PermissionConfig {
             site_admins: Vec::new(),
@@ -524,16 +526,15 @@ mod scenario_tests {
             },
         );
 
-        let mut user_roles = Vec::new();
         // User with multiple roles
-        user_roles.push(UserRole {
+        let user_roles = vec![UserRole {
             username: "power_user".to_string(),
             roles: vec![
                 "contributor".to_string(),
                 "moderator".to_string(),
                 "downloader".to_string(),
             ],
-        });
+        }];
 
         gallery_config.permissions = PermissionConfig {
             site_admins: Vec::new(),
@@ -615,15 +616,16 @@ mod scenario_tests {
             },
         );
 
-        let mut wedding_users = Vec::new();
-        wedding_users.push(UserRole {
-            username: "john_smith".to_string(),
-            roles: vec!["bride_groom".to_string()],
-        });
-        wedding_users.push(UserRole {
-            username: "jane_smith".to_string(),
-            roles: vec!["bride_groom".to_string()],
-        });
+        let wedding_users = vec![
+            UserRole {
+                username: "john_smith".to_string(),
+                roles: vec!["bride_groom".to_string()],
+            },
+            UserRole {
+                username: "jane_smith".to_string(),
+                roles: vec!["bride_groom".to_string()],
+            },
+        ];
         // All wedding guests would be added here
 
         wedding_folder.permissions = PermissionConfig {
@@ -674,11 +676,10 @@ mod scenario_tests {
             },
         );
 
-        let mut corp_users = Vec::new();
-        corp_users.push(UserRole {
+        let corp_users = vec![UserRole {
             username: "pr_manager".to_string(),
             roles: vec!["corp_pr".to_string()],
-        });
+        }];
 
         corporate_folder.permissions = PermissionConfig {
             site_admins: Vec::new(),

--- a/tenrankai/src/site/builder.rs
+++ b/tenrankai/src/site/builder.rs
@@ -137,6 +137,8 @@ impl SiteBuilder {
         static_handler.refresh_file_versions().await;
         template_engine.set_static_handler(static_handler.clone());
         template_engine.set_has_user_auth(self.config.user_database.is_some());
+        template_engine.set_site_title(self.config.site_title.clone());
+        template_engine.set_copyright_holder(self.config.copyright_holder.clone());
         template_engine.update_file_versions().await;
 
         Ok((template_engine, static_handler))

--- a/tenrankai/src/site/types.rs
+++ b/tenrankai/src/site/types.rs
@@ -25,6 +25,10 @@ pub struct SiteConfig {
     pub config_storage: Option<String>,
     pub site_admins: Vec<String>,
     pub hosted_mode: bool,
+    /// Display title for the site (page title, header heading, OG site_name).
+    pub site_title: Option<String>,
+    /// Copyright holder shown in the site footer.
+    pub copyright_holder: Option<String>,
 }
 
 /// Resources for a single site - encapsulates all site-specific components

--- a/tenrankai/src/templating.rs
+++ b/tenrankai/src/templating.rs
@@ -197,6 +197,12 @@ pub struct TemplateEngine {
     has_user_auth: bool,
     force_color_scheme: Option<String>,
     google_fonts: Vec<tenrankai_config_storage::GoogleFontConfig>,
+    /// Display title exposed to templates as `site_title`. Falls back to
+    /// "Tenrankai" when unset.
+    site_title: Option<String>,
+    /// Copyright holder exposed to templates as `copyright_holder`. Falls back
+    /// to the resolved site title when unset.
+    copyright_holder: Option<String>,
     file_versions: Arc<RwLock<HashMap<String, u64>>>,
     /// TTL for cached templates. Within this duration, cached templates are
     /// returned without checking file modification time (useful for S3 backends).
@@ -219,6 +225,8 @@ impl TemplateEngine {
             has_user_auth: false,
             force_color_scheme: None,
             google_fonts: Vec::new(),
+            site_title: None,
+            copyright_holder: None,
             file_versions: Arc::new(RwLock::new(HashMap::new())),
             cache_ttl: DEFAULT_TEMPLATE_CACHE_TTL,
         }
@@ -304,6 +312,14 @@ impl TemplateEngine {
 
     pub fn set_google_fonts(&mut self, fonts: Vec<tenrankai_config_storage::GoogleFontConfig>) {
         self.google_fonts = fonts;
+    }
+
+    pub fn set_site_title(&mut self, site_title: Option<String>) {
+        self.site_title = site_title;
+    }
+
+    pub fn set_copyright_holder(&mut self, copyright_holder: Option<String>) {
+        self.copyright_holder = copyright_holder;
     }
 
     fn create_parser_with_filters(
@@ -467,6 +483,25 @@ impl TemplateEngine {
         globals.insert(
             "current_year".into(),
             liquid::model::Value::scalar(current_year as i64),
+        );
+
+        // Add site identity for header/footer branding. `site_title` falls back
+        // to "Tenrankai"; `copyright_holder` falls back to the resolved title.
+        let site_title = self
+            .site_title
+            .clone()
+            .unwrap_or_else(|| "Tenrankai".to_string());
+        let copyright_holder = self
+            .copyright_holder
+            .clone()
+            .unwrap_or_else(|| site_title.clone());
+        globals.insert(
+            "site_title".into(),
+            liquid::model::Value::scalar(site_title),
+        );
+        globals.insert(
+            "copyright_holder".into(),
+            liquid::model::Value::scalar(copyright_holder),
         );
 
         // Add user auth flag
@@ -685,7 +720,7 @@ mod tests {
     #[tokio::test]
     async fn test_template_with_asset_url_filter() {
         // Create a template engine with file versions
-        let storage = Arc::new(FilesystemStorage::new(&PathBuf::from("templates")));
+        let storage = Arc::new(FilesystemStorage::new(PathBuf::from("templates")));
         let mut template_engine = TemplateEngine::new(vec![storage]);
 
         // Set up file versions

--- a/tests/admin_and_hidden_images_tests.rs
+++ b/tests/admin_and_hidden_images_tests.rs
@@ -90,6 +90,8 @@ fn create_admin_test_config(temp_dir: &TempDir, indexing_mode: ImageIndexingMode
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     }
 }
 
@@ -436,22 +438,15 @@ async fn test_image_detail_api_permissions() {
     let permissions = json.get("permissions").unwrap();
 
     // Public viewer role permissions
-    assert_eq!(
-        permissions.get("can_view").unwrap().as_bool().unwrap(),
-        true
-    );
-    assert_eq!(
-        permissions
+    assert!(permissions.get("can_view").unwrap().as_bool().unwrap());
+    assert!(
+        !permissions
             .get("can_see_hidden")
             .unwrap()
             .as_bool()
-            .unwrap(),
-        false
+            .unwrap()
     );
-    assert_eq!(
-        permissions.get("owner_access").unwrap().as_bool().unwrap(),
-        false
-    );
+    assert!(!permissions.get("owner_access").unwrap().as_bool().unwrap());
 }
 
 // ============================================================================
@@ -860,7 +855,7 @@ async fn test_admin_get_role() {
     let json: serde_json::Value = response.json();
     assert_eq!(json.get("name").unwrap().as_str().unwrap(), "viewer");
     assert!(json.get("permissions").is_some());
-    assert_eq!(json.get("is_builtin").unwrap().as_bool().unwrap(), true);
+    assert!(json.get("is_builtin").unwrap().as_bool().unwrap());
 }
 
 #[tokio::test]

--- a/tests/cascading_static_directories.rs
+++ b/tests/cascading_static_directories.rs
@@ -60,6 +60,8 @@ async fn test_cascading_static_directories() {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     };
 
     // Create the app
@@ -143,6 +145,8 @@ async fn test_favicon_cascading_directories() {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     };
 
     // Create the app

--- a/tests/gallery_integration_tests.rs
+++ b/tests/gallery_integration_tests.rs
@@ -124,6 +124,8 @@ fn create_test_config(temp_dir: &TempDir) -> SiteConfig {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     }
 }
 
@@ -811,10 +813,10 @@ async fn test_gallery_download_with_permission() {
     let mut config = create_test_config(&temp_dir);
 
     // Update the viewer role to include can_download_gallery
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_download_gallery = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_download_gallery = true;
     }
 
     // Create test images in main gallery
@@ -893,10 +895,10 @@ async fn test_gallery_download_zip_file_dates() {
     let mut config = create_test_config(&temp_dir);
 
     // Update the viewer role to include can_download_gallery
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_download_gallery = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_download_gallery = true;
     }
 
     // Create test images
@@ -950,10 +952,10 @@ async fn test_gallery_download_subfolder() {
     let mut config = create_test_config(&temp_dir);
 
     // Update the viewer role to include can_download_gallery
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_download_gallery = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_download_gallery = true;
     }
 
     // Create a subfolder with images
@@ -1002,10 +1004,10 @@ async fn test_gallery_download_empty_folder() {
     let mut config = create_test_config(&temp_dir);
 
     // Update the viewer role to include can_download_gallery
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_download_gallery = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_download_gallery = true;
     }
 
     // Create an empty subfolder
@@ -1031,10 +1033,10 @@ async fn test_gallery_download_recursive() {
     let mut config = create_test_config(&temp_dir);
 
     // Update the viewer role to include can_download_gallery
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_download_gallery = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_download_gallery = true;
     }
 
     // Create a folder structure with images in subfolders only (not at root)
@@ -1141,6 +1143,8 @@ fn create_test_config_with_raw_permission(temp_dir: &TempDir) -> SiteConfig {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     }
 }
 
@@ -1358,10 +1362,10 @@ async fn test_image_api_includes_versions() {
     let mut config = create_test_config(&temp_dir);
 
     // Set can_see_versions permission for viewer role
-    if let Some(ref mut galleries) = config.galleries {
-        if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
-            viewer_role.permissions.can_see_versions = true;
-        }
+    if let Some(ref mut galleries) = config.galleries
+        && let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer")
+    {
+        viewer_role.permissions.can_see_versions = true;
     }
 
     let photos_dir = std::path::Path::new(&config.galleries.as_ref().unwrap()[0].source_directory);
@@ -1438,7 +1442,7 @@ async fn run_older_version_navigation_test(indexing_mode: ImageIndexingMode) {
 
     // Set the indexing mode and add can_see_versions permission
     if let Some(ref mut galleries) = config.galleries {
-        galleries[0].image_indexing = indexing_mode.clone();
+        galleries[0].image_indexing = indexing_mode;
         if let Some(ref mut viewer_role) = galleries[0].permissions.roles.get_mut("viewer") {
             viewer_role.permissions.can_see_versions = true;
         }

--- a/tests/posts_integration.rs
+++ b/tests/posts_integration.rs
@@ -153,6 +153,8 @@ This is the content of the second test post."#;
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     };
 
     let app = create_app(config, None).await;

--- a/tests/sitemap_integration.rs
+++ b/tests/sitemap_integration.rs
@@ -100,6 +100,8 @@ async fn setup_test_server() -> (TempDir, TestServer) {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     };
 
     let app = create_app(config, None).await;

--- a/tests/template_integration.rs
+++ b/tests/template_integration.rs
@@ -85,6 +85,8 @@ async fn setup_test_server() -> (TempDir, TestServer) {
         config_storage: None,
         site_admins: Vec::new(),
         hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
     };
 
     let app = create_app(config, None).await;


### PR DESCRIPTION
## What

The shipped `templates/` hardcoded **theatr.us**-specific branding — the site name in the header/title, the copyright holder in the footer, and gallery/image meta-description fallbacks. This makes the default templates reusable for any tenrankai deployment.

### Config-driven site identity
- New per-site config values **`site_title`** and **`copyright_holder`** (`StoredSiteConfig` → `SiteConfig`), plumbed into the template engine and exposed to templates as the `site_title` / `copyright_holder` globals.
- Fallbacks: `site_title` → `"Tenrankai"`; `copyright_holder` → the resolved `site_title`. So a fresh install renders sensibly with no config.
- `_header` (`<title>`, `<h1>`, `og:site_name`), `_footer` (copyright), and the `gallery` / `image_detail` meta-description fallbacks now reference these globals instead of literal `theatr.us` / `Yann Ramin`.

### Generic page bodies
- `pages/index`, `pages/about`, `pages/contact` rewritten as neutral starter content; `pages/404` meta description de-branded.

Site-specific content (e.g. theatr.us's real index/about/contact) is supplied through a **template overlay directory** listed ahead of the shipped `templates` dir in the site config — tenrankai resolves each template first-match-wins, so these generic defaults are only used when not overridden. `config.d/` is gitignored, so that wiring is deployment-local and not part of this PR.

## Second commit — clippy cleanup
`chore: clear clippy --all-targets warnings` fixes pre-existing warnings surfaced by `cargo clippy --workspace --all-targets -- -D warnings` (CI runs clippy without `--all-targets`, so they weren't gated): `cmp_owned`, `useless_vec`, `needless_borrow(s)`, `field_reassign_with_default`, `vec_init_then_push`. No behavior change.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (with and without AVIF)
- `cargo fmt --check` — clean
- `cargo test --workspace --no-default-features` — 457 passed, 0 failed
- Ran the server against a theatr.us overlay with `site_title="theatr.us"` / `copyright_holder="Yann Ramin"`: header/footer/meta output is **byte-identical** to the previous hardcoded templates, and overlay-provided pages render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)