### PR TITLE
fix(sitemap): percent-encode image-detail URLs

### DIFF
--- a/tenrankai/src/sitemap.rs
+++ b/tenrankai/src/sitemap.rs
@@ -396,7 +396,8 @@ async fn collect_gallery_urls(
             }
             let url_id = gallery.build_url_identifier(image_path).await;
             image_urls.push(UrlEntry::new(format!(
-                "{base_url}{url_prefix}/detail/{url_id}"
+                "{base_url}{url_prefix}/detail/{}",
+                encode_path_segments(&url_id)
             )));
         }
     }

--- a/tests/sitemap_integration.rs
+++ b/tests/sitemap_integration.rs
@@ -52,6 +52,12 @@ async fn setup_test_server() -> (TempDir, TestServer) {
     .unwrap();
     write_image(&secret_dir.join("delta.jpg"));
 
+    // A public subfolder whose name contains a space, to exercise URL encoding
+    // of both folder and image-detail sitemap URLs.
+    let spaced_dir = photos_dir.join("big sur");
+    fs::create_dir_all(&spaced_dir).unwrap();
+    write_image(&spaced_dir.join("epsilon.jpg"));
+
     // A blog post.
     fs::write(
         posts_dir.join("hello-world.md"),
@@ -146,6 +152,31 @@ async fn sitemap_lists_public_resources() {
     // The restricted folder and its images must not be exposed.
     assert!(!xml.contains("/gallery/secret"));
     assert!(!xml.contains("delta.jpg"));
+}
+
+#[tokio::test]
+async fn sitemap_percent_encodes_urls_with_spaces() {
+    let (_temp_dir, server) = setup_test_server().await;
+
+    let response = server.get("/sitemap.xml").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let xml = response.text();
+
+    // Folder URLs are percent-encoded.
+    assert!(
+        xml.contains("<loc>https://example.com/gallery/big%20sur</loc>"),
+        "folder URL with a space should be percent-encoded:\n{xml}"
+    );
+    // Regression: image-detail URLs must be percent-encoded too, matching folders.
+    assert!(
+        xml.contains("https://example.com/gallery/detail/big%20sur/"),
+        "image-detail URL with a space should be percent-encoded:\n{xml}"
+    );
+    // No <loc> may contain a raw space, which is invalid in a sitemap and 404s.
+    assert!(
+        !xml.contains("/gallery/detail/big sur/"),
+        "image-detail URL must not contain a raw space:\n{xml}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Gallery **folder** sitemap URLs are percent-encoded (`sitemap.rs` uses `encode_path_segments`), but **image-detail** URLs interpolate the raw `url_id`:

```rust
"{base_url}{url_prefix}/detail/{url_id}"   // url_id used verbatim
```

For filename-indexed galleries `url_id` includes the folder path, so any folder/filename containing a space (or other reserved character) emits a `<loc>` with a literal space — which is invalid sitemap XML, 404s, and trips up crawlers.

Found via a health-check of a live sitemap — a folder named `C-2025 A6 Lemmon` (a comet) produced:

```
https://theatr.us/gallery/C-2025%20A6%20Lemmon             ← folder, encoded, 200 ✓
https://theatr.us/gallery/detail/C-2025 A6 Lemmon/12folo   ← image, raw space, 404 ✗
```

## Fix

Encode the image-detail `url_id` with the same `encode_path_segments` helper the folder URLs already use. One line:

```rust
"{base_url}{url_prefix}/detail/{}", encode_path_segments(&url_id)
```

`encode_path_segments` splits on `/` and encodes each segment, so `astrobin/C-2025 A6 Lemmon/12folo` → `astrobin/C-2025%20A6%20Lemmon/12folo` (verified to resolve 200).

## Test

Adds `sitemap_percent_encodes_urls_with_spaces`: a public folder named `big sur` must yield percent-encoded folder **and** image-detail URLs, with no raw space in any `<loc>`. Confirmed it **fails without the fix** and passes with it.

- `cargo test --workspace --no-default-features` → 458 passed, 0 failed
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)