### PR TITLE
[codex] Cache AOM source in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,7 +29,9 @@ users.toml
 LICENSE
 
 # CI/CD
-.github/
+.github/*
+!.github/cmake/
+!.github/cmake/aom-fetchcontent-cache.cmake
 
 # Test files
 tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,14 @@ RUN apt-get update && apt-get install -y \
     libaom-dev \
     && rm -rf /var/lib/apt/lists/*
 
+ARG AOM_VERSION=v3.12.1
+ARG AOM_COMMIT=10aece4157eb79315da205f39e19bf6ab3ee30d0
+
+# Preload the AOM source tree used by libavif-sys so CMake FetchContent does
+# not fetch the flaky googlesource archive during the Rust build.
+RUN git clone --depth 1 --branch "${AOM_VERSION}" https://aomedia.googlesource.com/aom /opt/aom \
+    && test "$(git -C /opt/aom rev-parse HEAD)" = "${AOM_COMMIT}"
+
 # Build and install libheif from source (need >= 1.21 for libheif-rs)
 # Use limited parallelism to avoid OOM during cross-compilation
 RUN git clone --depth 1 --branch v1.21.1 https://github.com/strukturag/libheif.git /tmp/libheif \
@@ -35,6 +43,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 
 # Set working directory
 WORKDIR /app
+
+COPY .github/cmake/aom-fetchcontent-cache.cmake /opt/aom-fetchcontent-cache.cmake
+ENV AOM_SOURCE_DIR=/opt/aom
+ENV CMAKE_TOOLCHAIN_FILE=/opt/aom-fetchcontent-cache.cmake
 
 # Copy workspace manifests and all crate Cargo.toml files first (for caching)
 COPY Cargo.toml Cargo.lock ./


### PR DESCRIPTION
## Summary
- Preload pinned AOM v3.12.1 source in the Docker builder stage
- Verify the checkout against the expected AOM commit
- Reuse the existing CMake FetchContent override so libavif-sys uses the local AOM source during cargo build
- Allow only the CMake shim from .github/cmake into the Docker build context

## Root cause
The main-branch Docker Publish workflow is failing during Docker image builds, not during GHCR login or push. The failing buildx step reaches Dockerfile line 73, cargo build --release -p tenrankai, where libavif-sys tries to download AOM from aomedia.googlesource.com and receives HTTP 503. The CI runner-level AOM cache from PR #238 does not apply inside Docker build containers.

## Validation
- Inspected failed Docker Publish run 28760145158 logs
- Confirmed both amd64 and arm64 fail in Build and push Docker image
- git diff --check
- Manually ran Docker Publish on this branch with publish=false: run 28761476665 passed for linux/amd64 and linux/arm64

Local Docker validation was not run because Docker is not installed in this workspace.