### PR TITLE
[codex] Clean up frontend legacy remnants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,10 +190,11 @@ cargo test -- --test-threads=4
 - Maintain responsive design principles
 - Test on mobile and desktop viewports
 
-### JavaScript Guidelines
+### Frontend Guidelines
 
-- Use modern JavaScript (ES6+) features
-- Export utilities via `window` object for template access
+- Keep behavior in the Vite TypeScript/React bundle under `frontend/react`
+- Do not add inline JavaScript behavior to Liquid templates
+- Avoid exporting browser globals for template access
 - Handle errors gracefully with user-friendly messages
 - Follow async/await patterns for API calls
 

--- a/frontend/react/app.ts
+++ b/frontend/react/app.ts
@@ -11,6 +11,7 @@ import './pages/gallery.tsx';
 import './pages/image-detail.tsx';
 import './pages/gallery-preview-template.ts';
 import './pages/login.ts';
+import './pages/login-success.ts';
 import './pages/passkey-enrollment.ts';
 import './pages/passkeys.ts';
 import './pages/profile.ts';

--- a/frontend/react/components/user-menu.ts
+++ b/frontend/react/components/user-menu.ts
@@ -59,29 +59,39 @@ class UserMenu {
       const data = await response.json() as VerifyResponse;
 
       if (data.authorized && data.username) {
-        const adminLink = data.is_admin ? '<a href="/_admin">Admin</a>' : '';
-        contentDiv.innerHTML = `
-          <div class="user-info">
-            Signed in as
-            <span class="username">${this.escapeHtml(data.username)}</span>
-          </div>
-          ${adminLink}
-          <a href="/_login/profile">Profile</a>
-          <a href="/_login/logout">Sign out</a>
-        `;
+        contentDiv.replaceChildren(...this.createSignedInMenu(data.username, Boolean(data.is_admin)));
       } else {
-        contentDiv.innerHTML = '<a href="/_login">Sign in</a>';
+        contentDiv.replaceChildren(this.createLink('/_login', 'Sign in'));
       }
     } catch (error) {
       console.error('Error checking auth status:', error);
-      contentDiv.innerHTML = '<a href="/_login">Sign in</a>';
+      contentDiv.replaceChildren(this.createLink('/_login', 'Sign in'));
     }
   }
 
-  private escapeHtml(text: string): string {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+  private createSignedInMenu(username: string, isAdmin: boolean): HTMLElement[] {
+    const userInfo = document.createElement('div');
+    userInfo.className = 'user-info';
+    userInfo.append('Signed in as');
+
+    const usernameElement = document.createElement('span');
+    usernameElement.className = 'username';
+    usernameElement.textContent = username;
+    userInfo.append(usernameElement);
+
+    return [
+      userInfo,
+      ...(isAdmin ? [this.createLink('/_admin', 'Admin')] : []),
+      this.createLink('/_login/profile', 'Profile'),
+      this.createLink('/_login/logout', 'Sign out'),
+    ];
+  }
+
+  private createLink(href: string, text: string): HTMLAnchorElement {
+    const link = document.createElement('a');
+    link.href = href;
+    link.textContent = text;
+    return link;
   }
 }
 

--- a/frontend/react/pages/gallery.tsx
+++ b/frontend/react/pages/gallery.tsx
@@ -172,14 +172,11 @@ const GalleryPage: React.FC<GalleryPageProps> = ({
 
 // Mount React masonry gallery on server-rendered page
 document.addEventListener('DOMContentLoaded', () => {
-  // Try to use the full gallery data first (includes metadata)
   const galleryDataElement = document.getElementById('gallery-data');
-  const imagesDataElement = document.getElementById('gallery-images');
 
   let galleryData: GalleryData | null = null;
   let images: GalleryItem[] = [];
 
-  // Try to parse the full gallery data
   if (galleryDataElement) {
     try {
       const jsonText = galleryDataElement.textContent || '{}';
@@ -187,16 +184,6 @@ document.addEventListener('DOMContentLoaded', () => {
       images = galleryData?.images || [];
     } catch (e) {
       console.error('Failed to parse gallery data:', e);
-    }
-  }
-
-  // Fall back to legacy images-only data if needed
-  if (!galleryData && imagesDataElement) {
-    try {
-      const jsonText = imagesDataElement.textContent || '[]';
-      images = JSON.parse(jsonText);
-    } catch (e) {
-      console.error('Failed to parse gallery images data:', e);
     }
   }
 
@@ -532,23 +519,12 @@ function mountFolderDescriptionEditor(galleryData: GalleryData | null) {
 }
 
 /**
- * Mount the "New" dropdown with Upload and New Folder options
- * This replaces the old "+ Folder" button with a dropdown
+ * Mount the "New" dropdown with Upload and New Folder options.
  */
 function mountNewDropdown(galleryData: GalleryData | null) {
-  // Look for either the new mount point or fall back to old button
-  let dropdownMount = document.getElementById('new-dropdown-mount');
-  const legacyButton = document.getElementById('create-folder-btn');
+  const dropdownMount = document.getElementById('new-dropdown-mount');
 
   if (!galleryData) return;
-
-  // If there's no mount point but there's a legacy button, replace it
-  if (!dropdownMount && legacyButton) {
-    dropdownMount = document.createElement('div');
-    dropdownMount.id = 'new-dropdown-mount';
-    dropdownMount.style.display = 'inline-block';
-    legacyButton.parentNode?.replaceChild(dropdownMount, legacyButton);
-  }
 
   if (!dropdownMount) return;
 

--- a/frontend/react/pages/image-detail.tsx
+++ b/frontend/react/pages/image-detail.tsx
@@ -30,6 +30,32 @@ interface Breadcrumb {
   is_current: boolean;
 }
 
+function createMountErrorFallback(): HTMLElement {
+  const fallback = document.createElement('div');
+  Object.assign(fallback.style, {
+    padding: '2rem',
+    textAlign: 'center',
+    border: '2px solid #dc3545',
+    background: '#f8d7da',
+    color: '#721c24',
+    borderRadius: '4px',
+  });
+
+  const title = document.createElement('h3');
+  title.textContent = 'React Enhancement Failed';
+
+  const message = document.createElement('p');
+  message.textContent = 'The image detail page could not be loaded properly.';
+
+  const reloadButton = document.createElement('button');
+  reloadButton.type = 'button';
+  reloadButton.textContent = 'Reload Page';
+  reloadButton.addEventListener('click', () => window.location.reload());
+
+  fallback.append(title, message, reloadButton);
+  return fallback;
+}
+
 function Breadcrumbs({ breadcrumbs, galleryUrl, currentImageTitle, imagePath }: {
   breadcrumbs: Breadcrumb[] | any;
   galleryUrl: string;
@@ -414,14 +440,6 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   } catch (error) {
     console.error('Failed to mount React image detail component:', error);
-    
-    // Show fallback message
-    container.innerHTML = `
-      <div style="padding: 2rem; text-align: center; border: 2px solid #dc3545; background: #f8d7da; color: #721c24; border-radius: 4px;">
-        <h3>React Enhancement Failed</h3>
-        <p>The image detail page could not be loaded properly.</p>
-        <button onclick="window.location.reload()">Reload Page</button>
-      </div>
-    `;
+    container.replaceChildren(createMountErrorFallback());
   }
 });

--- a/frontend/react/pages/login-success.ts
+++ b/frontend/react/pages/login-success.ts
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const redirectElement = document.getElementById('login-success-redirect');
+  if (!redirectElement) {
+    return;
+  }
+
+  const redirectUrl = redirectElement.dataset.redirectUrl || '/gallery';
+  const configuredDelay = Number.parseInt(redirectElement.dataset.redirectDelayMs || '', 10);
+  const redirectDelayMs = Number.isFinite(configuredDelay) ? configuredDelay : 3000;
+
+  window.setTimeout(() => {
+    window.location.href = redirectUrl;
+  }, redirectDelayMs);
+});

--- a/frontend/react/pages/passkeys.ts
+++ b/frontend/react/pages/passkeys.ts
@@ -1,6 +1,46 @@
-import { AuthUtils } from '../auth/auth-utils.ts';
 import { PasskeyManager, WebAuthnUtils } from '../auth/webauthn.ts';
+import type { PasskeyInfo } from '../auth/webauthn.ts';
 import { Toast } from '../ui/toast.ts';
+
+function createMessage(tagName: 'div' | 'p', className: string, text: string): HTMLElement {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  return element;
+}
+
+function createPasskeyItem(passkey: PasskeyInfo): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'passkey-item';
+  item.dataset.id = passkey.id;
+
+  const info = document.createElement('div');
+  info.className = 'passkey-info';
+
+  const name = document.createElement('div');
+  name.className = 'passkey-name';
+  name.textContent = passkey.name;
+
+  const meta = document.createElement('div');
+  meta.className = 'passkey-meta';
+  meta.textContent = `Created: ${PasskeyManager.formatDate(passkey.created_at)}`;
+  if (passkey.last_used_at) {
+    meta.append(` \u2022 Last used: ${PasskeyManager.formatDate(passkey.last_used_at)}`);
+  }
+
+  info.append(name, meta);
+
+  const deleteButton = document.createElement('button');
+  deleteButton.className = 'btn-delete';
+  deleteButton.dataset.passkeyId = passkey.id;
+  deleteButton.textContent = 'Delete';
+  deleteButton.addEventListener('click', () => {
+    void handleDeletePasskey(passkey.id);
+  });
+
+  item.append(info, deleteButton);
+  return item;
+}
 
 async function refreshPasskeysList(): Promise<void> {
   const listContainer = document.getElementById('passkeysList');
@@ -12,32 +52,12 @@ async function refreshPasskeysList(): Promise<void> {
     const passkeys = await PasskeyManager.loadPasskeys();
 
     if (passkeys.length === 0) {
-      listContainer.innerHTML = '<p class="no-passkeys">No passkeys registered yet.</p>';
+      listContainer.replaceChildren(createMessage('p', 'no-passkeys', 'No passkeys registered yet.'));
     } else {
-      listContainer.innerHTML = passkeys.map((passkey) => `
-        <div class="passkey-item" data-id="${AuthUtils.escapeHtml(passkey.id)}">
-          <div class="passkey-info">
-            <div class="passkey-name">${AuthUtils.escapeHtml(passkey.name)}</div>
-            <div class="passkey-meta">
-              Created: ${PasskeyManager.formatDate(passkey.created_at)}
-              ${passkey.last_used_at ? `\u2022 Last used: ${PasskeyManager.formatDate(passkey.last_used_at)}` : ''}
-            </div>
-          </div>
-          <button class="btn-delete" data-passkey-id="${AuthUtils.escapeHtml(passkey.id)}">Delete</button>
-        </div>
-      `).join('');
-
-      listContainer.querySelectorAll<HTMLElement>('[data-passkey-id]').forEach((button) => {
-        const passkeyId = button.dataset.passkeyId;
-        if (passkeyId) {
-          button.addEventListener('click', () => {
-            void handleDeletePasskey(passkeyId);
-          });
-        }
-      });
+      listContainer.replaceChildren(...passkeys.map((passkey) => createPasskeyItem(passkey)));
     }
   } catch {
-    listContainer.innerHTML = '<p class="error">Failed to load passkeys</p>';
+    listContainer.replaceChildren(createMessage('p', 'error', 'Failed to load passkeys'));
   }
 }
 
@@ -64,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (!WebAuthnUtils.isSupported()) {
     const addPasskeySection = document.querySelector<HTMLElement>('.add-passkey-section');
     if (addPasskeySection) {
-      addPasskeySection.innerHTML = '<div class="message info">Your browser does not support passkeys.</div>';
+      addPasskeySection.replaceChildren(createMessage('div', 'message info', 'Your browser does not support passkeys.'));
     }
   }
 

--- a/frontend/react/pages/profile.ts
+++ b/frontend/react/pages/profile.ts
@@ -1,5 +1,5 @@
-import { AuthUtils } from '../auth/auth-utils.ts';
 import { PasskeyManager } from '../auth/webauthn.ts';
+import type { PasskeyInfo } from '../auth/webauthn.ts';
 
 class ProfilePasskeys {
   private passkeyList: HTMLElement | null;
@@ -23,34 +23,58 @@ class ProfilePasskeys {
       const passkeys = await PasskeyManager.loadPasskeys();
 
       if (passkeys.length === 0) {
-        this.passkeyList.innerHTML = '<div class="loading">No passkeys found</div>';
+        this.passkeyList.replaceChildren(this.createMessage('loading', 'No passkeys found'));
         return;
       }
 
-      this.passkeyList.innerHTML = passkeys.map((passkey) => `
-        <div class="passkey-item" data-id="${AuthUtils.escapeHtml(passkey.id)}">
-          <div class="passkey-info">
-            <div class="passkey-name">${AuthUtils.escapeHtml(passkey.name || 'Unnamed Passkey')}</div>
-            <div class="passkey-created">Created: ${PasskeyManager.formatDate(passkey.created_at)}</div>
-          </div>
-          <div class="passkey-actions">
-            <button type="button" class="btn-danger" data-passkey-id="${AuthUtils.escapeHtml(passkey.id)}">Remove</button>
-          </div>
-        </div>
-      `).join('');
-
-      this.passkeyList.querySelectorAll<HTMLElement>('[data-passkey-id]').forEach((button) => {
-        const passkeyId = button.dataset.passkeyId;
-        if (passkeyId) {
-          button.addEventListener('click', () => {
-            void this.removePasskey(passkeyId);
-          });
-        }
-      });
+      this.passkeyList.replaceChildren(...passkeys.map((passkey) => this.createPasskeyItem(passkey)));
     } catch (error) {
       console.error('Error loading passkeys:', error);
-      this.passkeyList.innerHTML = '<div class="error">Failed to load passkeys</div>';
+      this.passkeyList.replaceChildren(this.createMessage('error', 'Failed to load passkeys'));
     }
+  }
+
+  private createPasskeyItem(passkey: PasskeyInfo): HTMLElement {
+    const item = document.createElement('div');
+    item.className = 'passkey-item';
+    item.dataset.id = passkey.id;
+
+    const info = document.createElement('div');
+    info.className = 'passkey-info';
+
+    const name = document.createElement('div');
+    name.className = 'passkey-name';
+    name.textContent = passkey.name || 'Unnamed Passkey';
+
+    const created = document.createElement('div');
+    created.className = 'passkey-created';
+    created.textContent = `Created: ${PasskeyManager.formatDate(passkey.created_at)}`;
+
+    info.append(name, created);
+
+    const actions = document.createElement('div');
+    actions.className = 'passkey-actions';
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'btn-danger';
+    removeButton.dataset.passkeyId = passkey.id;
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => {
+      void this.removePasskey(passkey.id);
+    });
+
+    actions.append(removeButton);
+    item.append(info, actions);
+
+    return item;
+  }
+
+  private createMessage(className: string, text: string): HTMLElement {
+    const message = document.createElement('div');
+    message.className = className;
+    message.textContent = text;
+    return message;
   }
 
   private async removePasskey(passkeyId: string): Promise<void> {

--- a/templates/modules/gallery.html.liquid
+++ b/templates/modules/gallery.html.liquid
@@ -127,10 +127,6 @@
                 <!-- React will render the masonry grid here -->
             </div>
 
-            <!-- Image data for React -->
-            <script type="application/json" id="gallery-images">
-{{ images_json }}
-            </script>
         {% endif %}
     {% else %}
         <p class="empty-gallery">No images found in this directory.</p>

--- a/templates/modules/login_success.html.liquid
+++ b/templates/modules/login_success.html.liquid
@@ -4,7 +4,7 @@
 {% include "_header.html.liquid" %}
 
 <div class="container">
-    <div class="success-container">
+    <div class="success-container" id="login-success-redirect" data-redirect-url="/gallery" data-redirect-delay-ms="3000">
         <h1>Login Successful!</h1>
         <p>You have been successfully logged in.</p>
         <p>You will be redirected to the gallery in a few seconds...</p>
@@ -12,13 +12,5 @@
         <a href="/gallery" class="btn-primary">Go to Gallery</a>
     </div>
 </div>
-
-
-<script>
-// Redirect to gallery after 3 seconds
-setTimeout(function() {
-    window.location.href = '/gallery';
-}, 3000);
-</script>
 
 {% include "_footer.html.liquid" %}

--- a/tenrankai/src/gallery/handlers.rs
+++ b/tenrankai/src/gallery/handlers.rs
@@ -142,9 +142,6 @@ pub async fn gallery_handler_for_named(
     // Check if this is the root path
     let is_root = path.is_empty() || path == "/";
 
-    // Convert images to JSON for client-side rendering (legacy)
-    let images_json = serde_json::to_string(&images).unwrap_or_else(|_| "[]".to_string());
-
     // Combine directories and images for the template's items array
     let mut items = directories.clone();
     items.extend(images.clone());
@@ -186,7 +183,6 @@ pub async fn gallery_handler_for_named(
         "breadcrumbs": breadcrumbs,
         "images": images,
         "items": items,
-        "images_json": images_json,
         "gallery_data_json": gallery_data_json,
         "folder_title": folder_title,
         "folder_description": folder_description,


### PR DESCRIPTION
## Summary
- move the login success redirect into the Vite bundle instead of an inline template script
- replace string-built auth/menu/passkey UI with DOM construction and textContent
- remove duplicate gallery image JSON and the old images-only frontend fallback
- remove an inline onclick from the image-detail mount error fallback
- update contributor frontend guidance away from window globals/template scripts

## Rendering checks
- captured baseline screenshots before edits using Playwright
- reran the same Playwright specs after edits and visually checked user menu, passkey profile, home preview fallback, and gallery grid screenshots

## Validation
- npm run lint
- npm run test
- npm run build
- cargo fmt
- cargo test --no-default-features
- npm run test:e2e

Note: npm run build still emits the existing Vite IIFE/import.meta warnings that predate this cleanup.