### PR TITLE
Bump crossbeam-epoch to 0.9.20 (fix RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
The daily **Security Audit** workflow began failing on 2026-07-07 after RUSTSEC-2026-0204 was published (2026-07-06). `crossbeam-epoch` < 0.9.20 has an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid.

`crossbeam-epoch` is a transitive dependency (via `rayon` → `image`/`rav1e`). This bumps the locked version to **0.9.20**, which contains the fix.

## Verification
- `cargo audit` now exits 0 (previously exit 1 with "1 vulnerability found").
- `cargo check --no-default-features` passes; only `Cargo.lock` changed (2 lines).

The pre-existing `ttf-parser` (unmaintained) and `anyhow` (unsound) advisories remain as non-failing warnings — they were already present on the last passing run and `cargo audit` does not fail on warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)