### PR TITLE
Path-style category URLs, RSS feeds, explicit hero rendering, clickable cards

### DIFF
--- a/e2e/tests/posts-editor.spec.ts
+++ b/e2e/tests/posts-editor.spec.ts
@@ -58,6 +58,10 @@ test.describe('posts editor (authenticated)', () => {
     await page.goto('/blog/private/secret-note');
     await expect(page.locator('.post-header h1')).toHaveText('Secret Note');
     await expect(page.locator('.post-edit-btn')).toBeVisible();
+
+    // Authenticated feeds include restricted posts
+    const feed = await page.request.get('/blog/feed.xml');
+    expect(await feed.text()).toContain('<title>Secret Note</title>');
   });
 
   test('creates, edits, and deletes a post through the UI', async ({ page }) => {

--- a/e2e/tests/posts-editor.spec.ts
+++ b/e2e/tests/posts-editor.spec.ts
@@ -56,7 +56,7 @@ test.describe('posts editor (authenticated)', () => {
     await expect(page.locator('.category-chip', { hasText: 'Private' })).toBeVisible();
 
     await page.goto('/blog/private/secret-note');
-    await expect(page.locator('.post-header h1')).toHaveText('Secret Note');
+    await expect(page.locator('.post-header > h1')).toHaveText('Secret Note');
     await expect(page.locator('.post-edit-btn')).toBeVisible();
 
     // Authenticated feeds include restricted posts
@@ -88,7 +88,7 @@ test.describe('posts editor (authenticated)', () => {
 
     await modal.getByRole('button', { name: 'Create' }).click();
     await page.waitForURL(`/blog/${CREATED_SLUG}`);
-    await expect(page.locator('.post-header h1')).toHaveText('E2E Editor Post');
+    await expect(page.locator('.post-header > h1')).toHaveText('E2E Editor Post');
     await expect(page.locator('.post-content')).toContainText('Written by a robot.');
     await expect(page.locator('.post-categories .category-label')).toHaveCount(2);
 
@@ -97,7 +97,7 @@ test.describe('posts editor (authenticated)', () => {
     await expect(modal).toBeVisible();
     await modal.locator('#post-title').fill('E2E Editor Post (edited)');
     await modal.getByRole('button', { name: 'Save' }).click();
-    await expect(page.locator('.post-header h1')).toHaveText('E2E Editor Post (edited)');
+    await expect(page.locator('.post-header > h1')).toHaveText('E2E Editor Post (edited)');
 
     // --- Delete (two-step confirm) ---
     await page.locator('.post-edit-btn').click();

--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -53,6 +53,10 @@ test.describe('posts index', () => {
     await expect(heroImg).toBeVisible();
     expect(await heroImg.getAttribute('src')).toContain('/g/_image/');
 
+    // A derived hero is not repeated above the post body on the detail page
+    await page.goto('/blog/camera-bag');
+    await expect(page.locator('.post-hero')).toHaveCount(0);
+
     // Plain Note has no images at all
     const plainNote = page.locator('.post-card', { hasText: 'Plain Note' });
     await expect(plainNote.locator('.post-card-image')).toHaveCount(0);
@@ -125,10 +129,29 @@ test.describe('posts index', () => {
     expect(missing.status()).toBe(404);
   });
 
-  test('shows an empty state for unknown categories', async ({ page }) => {
-    await page.goto('/blog?category=nonexistent');
-    await expect(page.locator('.post-card')).toHaveCount(0);
-    await expect(page.locator('.posts-empty')).toContainText('No posts found');
+  test('returns 404 for unknown categories', async ({ page }) => {
+    const response = await page.goto('/blog/category/nonexistent');
+    expect(response?.status()).toBe(404);
+  });
+
+  test('whole card is clickable', async ({ page }) => {
+    await page.goto('/blog');
+    // Click the summary text, not the title link. The stretched link overlays
+    // the card (which Playwright reports as interception), so force the click
+    // and let the browser hit-test it onto the overlay.
+    await page
+      .locator('.post-card', { hasText: 'Camera Bag' })
+      .locator('.post-card-summary')
+      .click({ force: true });
+    await expect(page).toHaveURL(/\/blog\/camera-bag$/);
+
+    // Category labels inside a card still navigate to the category, not the post
+    await page.goto('/blog');
+    await page
+      .locator('.post-card', { hasText: 'Camera Bag' })
+      .locator('.category-label', { hasText: 'Gear' })
+      .click();
+    await expect(page).toHaveURL(/\/blog\/category\/gear$/);
   });
 });
 
@@ -136,7 +159,7 @@ test.describe('post detail', () => {
   test('renders content, categories, and social meta tags', async ({ page }) => {
     await page.goto('/blog/first-trip');
 
-    await expect(page.locator('.post-header h1')).toHaveText('First Trip');
+    await expect(page.locator('.post-header > h1')).toHaveText('First Trip');
     await expect(page.locator('.post-meta')).toContainText('January 1, 2024');
     await expect(page.locator('.post-meta')).toContainText('min read');
 
@@ -144,6 +167,11 @@ test.describe('post detail', () => {
     const label = page.locator('.post-categories .category-label');
     await expect(label).toHaveText('Travel');
     expect(await label.getAttribute('href')).toBe('/blog/category/travel');
+
+    // The explicit hero image renders above the post body
+    const hero = page.locator('.post-hero img');
+    await expect(hero).toBeVisible();
+    expect(await hero.getAttribute('src')).toContain('/g/_image/');
 
     // Open Graph tags including og:image from the hero
     const ogType = page.locator('meta[property="og:type"]');

--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -32,13 +32,16 @@ test.describe('posts index', () => {
     await page.goto('/blog');
 
     const chips = page.locator('.category-bar .category-chip');
-    await expect(chips).toHaveCount(3); // All, Gear, Travel
+    await expect(chips).toHaveCount(4); // All, Gear, Travel, RSS
     await expect(chips.nth(0)).toHaveText('All');
     await expect(chips.nth(0)).toHaveClass(/active/);
     await expect(chips.nth(1)).toContainText('Gear');
     await expect(chips.nth(1).locator('.category-count')).toHaveText('2');
     await expect(chips.nth(2)).toContainText('Travel');
     await expect(chips.nth(2).locator('.category-count')).toHaveText('2');
+
+    const rss = page.locator('.category-bar .feed-chip');
+    expect(await rss.getAttribute('href')).toBe('/blog/feed.xml');
   });
 
   test('renders hero images from gallery references', async ({ page }) => {
@@ -59,7 +62,7 @@ test.describe('posts index', () => {
     await page.goto('/blog');
     await page.locator('.category-bar .category-chip', { hasText: 'Travel' }).click();
 
-    await expect(page).toHaveURL(/\?category=travel$/);
+    await expect(page).toHaveURL(/\/blog\/category\/travel$/);
     const cards = page.locator('.post-card');
     await expect(cards).toHaveCount(2);
     await expect(cards.nth(0).locator('h2')).toHaveText('Second Trip');
@@ -89,9 +92,37 @@ test.describe('posts index', () => {
     await expect(cards).not.toHaveClass(/featured/);
 
     // Filtered views fit on one page, so no pagination is rendered
-    await page.goto('/blog?category=gear');
+    await page.goto('/blog/category/gear');
     await expect(page.locator('.post-card')).toHaveCount(2);
     await expect(page.locator('.posts-pagination')).toHaveCount(0);
+  });
+
+  test('redirects legacy query-parameter category URLs', async ({ page }) => {
+    await page.goto('/blog?category=gear');
+    await expect(page).toHaveURL(/\/blog\/category\/gear$/);
+    await expect(page.locator('.post-card')).toHaveCount(2);
+  });
+
+  test('serves RSS feeds globally and per category', async ({ page }) => {
+    const feed = await page.request.get('/blog/feed.xml');
+    expect(feed.status()).toBe(200);
+    expect(feed.headers()['content-type']).toContain('application/rss+xml');
+    const xml = await feed.text();
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain('<title>Plain Note</title>');
+    expect(xml).toContain('<link>http://localhost:4319/blog/first-trip</link>');
+    // Restricted posts are excluded from anonymous feeds
+    expect(xml).not.toContain('Secret Note');
+
+    const gearFeed = await page.request.get('/blog/category/gear/feed.xml');
+    expect(gearFeed.status()).toBe(200);
+    const gearXml = await gearFeed.text();
+    expect(gearXml).toContain('<title>Camera Bag</title>');
+    expect(gearXml).toContain('<title>Second Trip</title>');
+    expect(gearXml).not.toContain('Plain Note');
+
+    const missing = await page.request.get('/blog/category/nonexistent/feed.xml');
+    expect(missing.status()).toBe(404);
   });
 
   test('shows an empty state for unknown categories', async ({ page }) => {
@@ -112,7 +143,7 @@ test.describe('post detail', () => {
     // Category labels link back to the filtered index
     const label = page.locator('.post-categories .category-label');
     await expect(label).toHaveText('Travel');
-    expect(await label.getAttribute('href')).toBe('/blog?category=travel');
+    expect(await label.getAttribute('href')).toBe('/blog/category/travel');
 
     // Open Graph tags including og:image from the hero
     const ogType = page.locator('meta[property="og:type"]');

--- a/posts/blog/example-post.md
+++ b/posts/blog/example-post.md
@@ -19,7 +19,7 @@ Every post must start with TOML front matter between `+++` delimiters. The requi
 
 Optional fields:
 
-- **categories**: A list of category labels, e.g. `categories = ["Travel", "Photo Gear"]`. Categories appear as labels on the index and each post, and the index can be filtered by category (`/blog?category=photo-gear`).
+- **categories**: A list of category labels, e.g. `categories = ["Travel", "Photo Gear"]`. Categories appear as labels on the index and each post, and each category gets its own index page (`/blog/category/photo-gear`) and RSS feed (`/blog/category/photo-gear/feed.xml`). A site-wide feed is served at `/blog/feed.xml`.
 - **hero_image**: An image shown on the index card and used for social media previews. Accepts a plain URL or a gallery reference like `"gallery:main:vacation/beach.jpg"`. If omitted, the first image in the post is used.
 
 ## Markdown Features

--- a/static/post-detail.css
+++ b/static/post-detail.css
@@ -61,6 +61,17 @@
     font-size: 0.9rem;
 }
 
+.post-hero {
+    margin: 0 0 var(--spacing-xl) 0;
+}
+
+.post-hero img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
 .post-categories {
     display: flex;
     flex-wrap: wrap;

--- a/static/posts-index.css
+++ b/static/posts-index.css
@@ -87,6 +87,7 @@
 }
 
 .post-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     background-color: var(--bg-card);
@@ -94,6 +95,20 @@
     border-radius: 8px;
     overflow: hidden;
     transition: border-color 0.15s ease, transform 0.15s ease;
+    cursor: pointer;
+}
+
+/* Stretch the title link over the whole card so anywhere on it opens the
+   post; interactive children re-raise themselves above the overlay */
+.post-card h2 a::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+}
+
+.post-card-categories {
+    position: relative;
+    z-index: 1;
 }
 
 .post-card:hover {

--- a/templates/modules/post_detail.html.liquid
+++ b/templates/modules/post_detail.html.liquid
@@ -27,6 +27,12 @@
         </p>
     </header>
 
+    {% if post.hero_image and post.hero_image_explicit %}
+    <figure class="post-hero">
+        <img src="{{ post.hero_image }}" alt="">
+    </figure>
+    {% endif %}
+
     <div class="post-content content">
         {{ post.html_content }}
     </div>

--- a/templates/modules/posts_index.html.liquid
+++ b/templates/modules/posts_index.html.liquid
@@ -22,7 +22,7 @@
             {{ category.name }}<span class="category-count">{{ category.count }}</span>
         </a>
         {% endfor %}
-        <a href="{{ feed_url }}" class="category-chip feed-chip" title="RSS feed">
+        <a href="{{ rss_feed_url }}" class="category-chip feed-chip" title="RSS feed">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 20.82a2.18 2.18 0 1 1-4.36 0 2.18 2.18 0 0 1 4.36 0zM1.82 8.91v3.05c5.65 0 10.22 4.57 10.22 10.22h3.05c0-7.33-5.94-13.27-13.27-13.27zm0-6.09v3.05c9.01 0 16.31 7.3 16.31 16.31h3.05C21.18 11.5 12.5 2.82 1.82 2.82z"/></svg>
             RSS
         </a>

--- a/templates/modules/posts_index.html.liquid
+++ b/templates/modules/posts_index.html.liquid
@@ -14,7 +14,7 @@
         {% endif %}
     </header>
 
-    {% if categories.size > 0 %}
+    {% if posts.size > 0 or categories.size > 0 %}
     <nav class="category-bar" aria-label="Post categories">
         <a href="{{ url_prefix }}" class="category-chip{% unless active_category %} active{% endunless %}">All</a>
         {% for category in categories %}
@@ -22,6 +22,10 @@
             {{ category.name }}<span class="category-count">{{ category.count }}</span>
         </a>
         {% endfor %}
+        <a href="{{ feed_url }}" class="category-chip feed-chip" title="RSS feed">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 20.82a2.18 2.18 0 1 1-4.36 0 2.18 2.18 0 0 1 4.36 0zM1.82 8.91v3.05c5.65 0 10.22 4.57 10.22 10.22h3.05c0-7.33-5.94-13.27-13.27-13.27zm0-6.09v3.05c9.01 0 16.31 7.3 16.31 16.31h3.05C21.18 11.5 12.5 2.82 1.82 2.82z"/></svg>
+            RSS
+        </a>
     </nav>
     {% endif %}
 
@@ -60,13 +64,13 @@
         {% if total_pages > 1 %}
             <nav class="posts-pagination">
                 {% if has_prev %}
-                    <a href="{{ url_prefix }}?page={{ prev_page }}{{ category_query }}" class="prev">← Previous</a>
+                    <a href="{{ page_base }}?page={{ prev_page }}" class="prev">← Previous</a>
                 {% endif %}
 
                 <span class="page-info">Page {{ current_page | plus: 1 }} of {{ total_pages }}</span>
 
                 {% if has_next %}
-                    <a href="{{ url_prefix }}?page={{ next_page }}{{ category_query }}" class="next">Next →</a>
+                    <a href="{{ page_base }}?page={{ next_page }}" class="next">Next →</a>
                 {% endif %}
             </nav>
         {% endif %}

--- a/templates/partials/_header.html.liquid
+++ b/templates/partials/_header.html.liquid
@@ -45,6 +45,10 @@
     {% if twitter_image %}
     <meta name="twitter:image" content="{{ twitter_image }}">
     {% endif %}
+
+    {% if rss_feed_url %}
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ rss_feed_url }}">
+    {% endif %}
     
     <!-- Favicons -->
     <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">

--- a/tenrankai/src/lib.rs
+++ b/tenrankai/src/lib.rs
@@ -991,6 +991,46 @@ fn create_router(app_state: AppState, built_site: Arc<site::Site>) -> axum::Rout
             }),
         );
 
+        // RSS feed for the whole posts system
+        router = router.route(
+            &format!("{}/feed.xml", prefix),
+            axum::routing::get({
+                let name = name.clone();
+                move |state, auth| posts::handlers::posts_feed_handler(state, Path(name), auth)
+            }),
+        );
+
+        // Category index and per-category feed ("category" is a reserved slug)
+        router = router.route(
+            &format!("{}/category/{{category}}", prefix),
+            axum::routing::get({
+                let name = name.clone();
+                move |state, path: Path<String>, auth, query| {
+                    let category = path.0;
+                    posts::handlers::posts_category_index_handler(
+                        state,
+                        Path((name, category)),
+                        auth,
+                        query,
+                    )
+                }
+            }),
+        );
+        router = router.route(
+            &format!("{}/category/{{category}}/feed.xml", prefix),
+            axum::routing::get({
+                let name = name.clone();
+                move |state, path: Path<String>, auth| {
+                    let category = path.0;
+                    posts::handlers::posts_category_feed_handler(
+                        state,
+                        Path((name, category)),
+                        auth,
+                    )
+                }
+            }),
+        );
+
         // Detail route for individual posts
         router = router.route(
             &format!("{}/{{*slug}}", prefix),

--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -84,6 +84,14 @@ impl PostsManager {
             if entry.path.ends_with(".md") || entry.path.ends_with(".markdown") {
                 match self.load_post(&entry.path).await {
                     Ok(post) => {
+                        if post.slug == "category" || post.slug.starts_with("category/") {
+                            warn!(
+                                "Skipping post {}: the 'category' path segment is reserved \
+                                 for category index URLs and the post would be unreachable",
+                                entry.path
+                            );
+                            continue;
+                        }
                         debug!("Loaded post: {}", post.slug);
                         new_posts.insert(post.slug.clone(), post);
                     }
@@ -222,6 +230,7 @@ impl PostsManager {
         let parser = Parser::new_ext(&markdown_content, options);
         let (html_content, first_image) = self.process_markdown_with_gallery_refs(parser).await;
 
+        let hero_image_explicit = metadata.hero_image.is_some();
         let hero_image = match &metadata.hero_image {
             Some(reference) => self.resolve_image_reference(reference).await,
             None => first_image,
@@ -239,6 +248,7 @@ impl PostsManager {
             html_content,
             categories: metadata.categories,
             hero_image,
+            hero_image_explicit,
             reading_time_minutes,
             last_modified,
         })
@@ -340,34 +350,50 @@ impl PostsManager {
         }
     }
 
-    pub async fn get_posts_page(
+    /// Posts visible to the user (newest first), optionally filtered by
+    /// category, windowed by skip/limit
+    async fn visible_posts(
         &self,
-        page: usize,
         category: Option<&str>,
         username: Option<&str>,
-    ) -> Vec<PostSummary> {
+        skip: usize,
+        limit: usize,
+    ) -> Vec<Post> {
         let posts = self.posts.read().await;
         let slugs = self.sorted_slugs.read().await;
         let folder_perms = self.folder_permissions.read().await;
         let mut visibility = HashMap::new();
-
-        let start = page * self.config.posts_per_page;
 
         slugs
             .iter()
             .filter_map(|slug| posts.get(slug))
             .filter(|post| Self::matches_category(post, category))
             .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, username))
-            .skip(start)
-            .take(self.config.posts_per_page)
+            .skip(skip)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    pub async fn get_posts_page(
+        &self,
+        page: usize,
+        category: Option<&str>,
+        username: Option<&str>,
+    ) -> Vec<PostSummary> {
+        let start = page * self.config.posts_per_page;
+
+        self.visible_posts(category, username, start, self.config.posts_per_page)
+            .await
+            .into_iter()
             .map(|post| PostSummary {
-                slug: post.slug.clone(),
-                title: post.title.clone(),
-                summary: post.summary.clone(),
-                date: post.date,
                 url: format!("{}/{}", self.config.url_prefix, post.slug),
-                categories: post.categories.clone(),
-                hero_image: post.hero_image.clone(),
+                slug: post.slug,
+                title: post.title,
+                summary: post.summary,
+                date: post.date,
+                categories: post.categories,
+                hero_image: post.hero_image,
                 reading_time_minutes: post.reading_time_minutes,
             })
             .collect()
@@ -381,19 +407,7 @@ impl PostsManager {
         category: Option<&str>,
         username: Option<&str>,
     ) -> Vec<Post> {
-        let posts = self.posts.read().await;
-        let slugs = self.sorted_slugs.read().await;
-        let folder_perms = self.folder_permissions.read().await;
-        let mut visibility = HashMap::new();
-
-        slugs
-            .iter()
-            .filter_map(|slug| posts.get(slug))
-            .filter(|post| Self::matches_category(post, category))
-            .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, username))
-            .take(limit)
-            .cloned()
-            .collect()
+        self.visible_posts(category, username, 0, limit).await
     }
 
     fn matches_category(post: &Post, category: Option<&str>) -> bool {

--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -373,6 +373,29 @@ impl PostsManager {
             .collect()
     }
 
+    /// The most recent posts visible to the user, with full content — used
+    /// for feed generation
+    pub async fn get_recent_posts(
+        &self,
+        limit: usize,
+        category: Option<&str>,
+        username: Option<&str>,
+    ) -> Vec<Post> {
+        let posts = self.posts.read().await;
+        let slugs = self.sorted_slugs.read().await;
+        let folder_perms = self.folder_permissions.read().await;
+        let mut visibility = HashMap::new();
+
+        slugs
+            .iter()
+            .filter_map(|slug| posts.get(slug))
+            .filter(|post| Self::matches_category(post, category))
+            .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, username))
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
     fn matches_category(post: &Post, category: Option<&str>) -> bool {
         match category {
             Some(wanted) => post
@@ -514,10 +537,17 @@ impl PostsManager {
     }
 
     /// Validate a slug for a new post: `/`-separated segments of letters,
-    /// digits, hyphens, and underscores, where no segment starts with `_`
+    /// digits, hyphens, and underscores, where no segment starts with `_`.
+    /// The first segment `category` is reserved for category index routes.
     pub fn validate_slug(slug: &str) -> Result<(), PostsError> {
         if slug.is_empty() {
             return Err(PostsError::InvalidSlug("slug cannot be empty".to_string()));
+        }
+
+        if slug == "category" || slug.starts_with("category/") {
+            return Err(PostsError::InvalidSlug(
+                "'category' is reserved for category index URLs".to_string(),
+            ));
         }
 
         for segment in slug.split('/') {

--- a/tenrankai/src/posts/handlers.rs
+++ b/tenrankai/src/posts/handlers.rs
@@ -9,10 +9,8 @@ use serde::Deserialize;
 use tracing::error;
 
 #[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct PostsQuery {
     page: Option<usize>,
-    category: Option<String>,
 }
 
 fn format_date(date: &DateTime<Utc>) -> String {
@@ -60,30 +58,49 @@ pub async fn posts_index_handler(
     ResolvedState(app_state): ResolvedState,
     Path(posts_name): Path<String>,
     auth: crate::login::OptionalAuth,
-    Query(query): Query<PostsQuery>,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
 ) -> axum::response::Response {
-    // Legacy ?category= URLs redirect permanently to the canonical path form
-    if let Some(category) = query.category.as_deref() {
+    let raw_query = raw_query.unwrap_or_default();
+    let mut category: Option<String> = None;
+    let mut page = 0usize;
+    let mut other_params: Vec<&str> = Vec::new();
+
+    for pair in raw_query.split('&').filter(|p| !p.is_empty()) {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "category" => {
+                let value = value.replace('+', " ");
+                category = urlencoding::decode(&value)
+                    .map(|v| v.into_owned())
+                    .ok()
+                    .or(Some(value));
+            }
+            "page" => page = value.parse().unwrap_or(0),
+            _ => other_params.push(pair),
+        }
+    }
+
+    // Legacy ?category= URLs redirect permanently to the canonical path
+    // form, keeping any unrelated query parameters
+    if let Some(category) = category.as_deref() {
         let slug = PostsManager::category_slug(category);
         if !slug.is_empty()
             && let Some(manager) = app_state.posts_managers().get(&posts_name)
         {
             let mut target = category_url(&manager.get_config().url_prefix, &slug);
-            if let Some(page) = query.page.filter(|p| *p > 0) {
-                target.push_str(&format!("?page={}", page));
+            let mut params: Vec<String> = other_params.iter().map(|p| p.to_string()).collect();
+            if page > 0 {
+                params.push(format!("page={}", page));
+            }
+            if !params.is_empty() {
+                target.push('?');
+                target.push_str(&params.join("&"));
             }
             return axum::response::Redirect::permanent(&target).into_response();
         }
     }
 
-    render_posts_index(
-        app_state,
-        posts_name,
-        None,
-        query.page.unwrap_or(0),
-        auth.username(),
-    )
-    .await
+    render_posts_index(app_state, posts_name, None, page, auth.username()).await
 }
 
 pub async fn posts_category_index_handler(
@@ -157,6 +174,13 @@ async fn render_posts_index(
             .find(|c| c.slug == slug)
             .map(|c| c.name.clone())
     });
+
+    // A category page for a category with no visible posts is a 404, matching
+    // the feed handler
+    if category_filter.is_some() && active_category.is_none() {
+        return ApiResponse::PostNotFound.into_response();
+    }
+
     let categories: Vec<_> = all_categories
         .iter()
         .map(|c| {
@@ -175,14 +199,10 @@ async fn render_posts_index(
         Some(slug) => category_url(&config.url_prefix, slug),
         None => config.url_prefix.clone(),
     };
-    let page_base_for_og = page_base.clone();
-
-    let feed_url = match category_filter.as_deref() {
-        Some(slug) => format!("{}/feed.xml", category_url(&config.url_prefix, slug)),
-        None => format!("{}/feed.xml", config.url_prefix),
-    };
+    let feed_url = format!("{}/feed.xml", page_base);
 
     let base_url = app_state.base_url().unwrap_or("http://localhost:8080");
+    let og_url = format!("{}{}", base_url, page_base);
 
     let page_title = match &active_category {
         Some(name) => format!("{} – {}", capitalize(&posts_name), name),
@@ -201,7 +221,6 @@ async fn render_posts_index(
         "categories": categories,
         "active_category": active_category,
         "page_base": page_base,
-        "feed_url": feed_url.clone(),
         "rss_feed_url": feed_url,
         "current_page": page,
         "total_pages": total_pages,
@@ -214,7 +233,7 @@ async fn render_posts_index(
         "meta_description": meta_description.clone(),
         "og_title": page_title,
         "og_description": meta_description,
-        "og_url": format!("{}{}", base_url, page_base_for_og),
+        "og_url": og_url,
         "og_type": "website",
     });
 
@@ -284,6 +303,7 @@ pub async fn post_detail_handler(
             "html_content": post.html_content,
             "categories": category_objects(&config.url_prefix, &post.categories),
             "hero_image": post.hero_image,
+            "hero_image_explicit": post.hero_image_explicit,
             "reading_time_minutes": post.reading_time_minutes,
         },
         "posts_name": posts_name,
@@ -343,7 +363,7 @@ async fn render_posts_feed(
     category: Option<String>,
     username: Option<&str>,
 ) -> axum::response::Response {
-    use crate::sitemap::xml_escape;
+    use crate::sitemap::{encode_path_segments, xml_escape};
 
     let posts_manager = match app_state.posts_managers().get(&posts_name) {
         Some(manager) => manager,
@@ -356,21 +376,27 @@ async fn render_posts_feed(
         .map(PostsManager::category_slug)
         .filter(|slug| !slug.is_empty());
 
-    // A category feed for an unknown category is a 404, not an empty feed
+    let posts = posts_manager
+        .get_recent_posts(FEED_ITEM_LIMIT, category_slug.as_deref(), username)
+        .await;
+
+    // A category feed for a category with no visible posts is a 404, not an
+    // empty feed; the display name comes from the matching label
     let category_name = match category_slug.as_deref() {
         Some(slug) => {
-            let categories = posts_manager.get_categories(username).await;
-            match categories.into_iter().find(|c| c.slug == slug) {
-                Some(c) => Some(c.name),
+            let name = posts.first().and_then(|post| {
+                post.categories
+                    .iter()
+                    .find(|c| PostsManager::category_slug(c) == slug)
+                    .cloned()
+            });
+            match name {
+                Some(name) => Some(name),
                 None => return ApiResponse::NotFound.into_response(),
             }
         }
         None => None,
     };
-
-    let posts = posts_manager
-        .get_recent_posts(FEED_ITEM_LIMIT, category_slug.as_deref(), username)
-        .await;
 
     let base_url = app_state.base_url().unwrap_or("http://localhost:8080");
     let site_title = app_state.template_engine().site_title();
@@ -413,7 +439,12 @@ async fn render_posts_feed(
     }
 
     for post in &posts {
-        let link = format!("{}{}/{}", base_url, config.url_prefix, post.slug);
+        let link = format!(
+            "{}{}/{}",
+            base_url,
+            config.url_prefix,
+            encode_path_segments(&post.slug)
+        );
         xml.push_str("<item>\n");
         xml.push_str(&format!("<title>{}</title>\n", xml_escape(&post.title)));
         xml.push_str(&format!("<link>{}</link>\n", xml_escape(&link)));
@@ -431,8 +462,9 @@ async fn render_posts_feed(
         }
         xml.push_str(&format!(
             "<content:encoded><![CDATA[{}]]></content:encoded>\n",
-            // CDATA cannot contain "]]>"; split any occurrence across sections
-            post.html_content.replace("]]>", "]]]]><![CDATA[>")
+            // Feed readers have no base URI for relative links, and CDATA
+            // cannot contain "]]>"
+            absolutize_html_urls(&post.html_content, base_url).replace("]]>", "]]]]><![CDATA[>")
         ));
         xml.push_str("</item>\n");
     }
@@ -440,13 +472,55 @@ async fn render_posts_feed(
     xml.push_str("</channel>\n</rss>\n");
 
     (
-        [(
-            axum::http::header::CONTENT_TYPE,
-            "application/rss+xml; charset=utf-8",
-        )],
+        [
+            (
+                axum::http::header::CONTENT_TYPE,
+                "application/rss+xml; charset=utf-8",
+            ),
+            // The body varies with the session cookie (restricted posts), so
+            // shared caches must not mix authenticated and anonymous copies
+            (axum::http::header::VARY, "Cookie"),
+            (
+                axum::http::header::CACHE_CONTROL,
+                if username.is_some() {
+                    "private, no-store"
+                } else {
+                    "public, max-age=300"
+                },
+            ),
+        ],
         xml,
     )
         .into_response()
+}
+
+/// Rewrite root-relative `src`/`href` attribute URLs to absolute ones
+fn absolutize_html_urls(html: &str, base_url: &str) -> String {
+    let mut out = String::with_capacity(html.len() + 256);
+    let mut rest = html;
+
+    loop {
+        let next = ["src=\"/", "href=\"/"]
+            .iter()
+            .filter_map(|pattern| rest.find(pattern).map(|pos| (pos, pattern.len())))
+            .min();
+
+        let Some((pos, pattern_len)) = next else {
+            out.push_str(rest);
+            return out;
+        };
+
+        let after_slash = pos + pattern_len;
+        // Keep protocol-relative URLs ("//example.com/...") untouched
+        if rest[after_slash..].starts_with('/') {
+            out.push_str(&rest[..after_slash]);
+        } else {
+            out.push_str(&rest[..after_slash - 1]);
+            out.push_str(base_url);
+            out.push('/');
+        }
+        rest = &rest[after_slash..];
+    }
 }
 
 fn capitalize(name: &str) -> String {

--- a/tenrankai/src/posts/handlers.rs
+++ b/tenrankai/src/posts/handlers.rs
@@ -38,6 +38,10 @@ fn format_date(date: &DateTime<Utc>) -> String {
     )
 }
 
+fn category_url(url_prefix: &str, slug: &str) -> String {
+    format!("{}/category/{}", url_prefix, slug)
+}
+
 fn category_objects(url_prefix: &str, categories: &[String]) -> Vec<liquid::Object> {
     categories
         .iter()
@@ -46,7 +50,7 @@ fn category_objects(url_prefix: &str, categories: &[String]) -> Vec<liquid::Obje
             liquid::object!({
                 "name": name,
                 "slug": slug.clone(),
-                "url": format!("{}?category={}", url_prefix, slug),
+                "url": category_url(url_prefix, &slug),
             })
         })
         .collect()
@@ -57,11 +61,55 @@ pub async fn posts_index_handler(
     Path(posts_name): Path<String>,
     auth: crate::login::OptionalAuth,
     Query(query): Query<PostsQuery>,
-) -> impl IntoResponse {
-    let page = query.page.unwrap_or(0);
-    let username = auth.username();
-    let category_filter = query
-        .category
+) -> axum::response::Response {
+    // Legacy ?category= URLs redirect permanently to the canonical path form
+    if let Some(category) = query.category.as_deref() {
+        let slug = PostsManager::category_slug(category);
+        if !slug.is_empty()
+            && let Some(manager) = app_state.posts_managers().get(&posts_name)
+        {
+            let mut target = category_url(&manager.get_config().url_prefix, &slug);
+            if let Some(page) = query.page.filter(|p| *p > 0) {
+                target.push_str(&format!("?page={}", page));
+            }
+            return axum::response::Redirect::permanent(&target).into_response();
+        }
+    }
+
+    render_posts_index(
+        app_state,
+        posts_name,
+        None,
+        query.page.unwrap_or(0),
+        auth.username(),
+    )
+    .await
+}
+
+pub async fn posts_category_index_handler(
+    ResolvedState(app_state): ResolvedState,
+    Path((posts_name, category)): Path<(String, String)>,
+    auth: crate::login::OptionalAuth,
+    Query(query): Query<PostsQuery>,
+) -> axum::response::Response {
+    render_posts_index(
+        app_state,
+        posts_name,
+        Some(category),
+        query.page.unwrap_or(0),
+        auth.username(),
+    )
+    .await
+}
+
+async fn render_posts_index(
+    app_state: crate::AppState,
+    posts_name: String,
+    category: Option<String>,
+    page: usize,
+    username: Option<&str>,
+) -> axum::response::Response {
+    let category_filter = category
         .as_deref()
         .map(PostsManager::category_slug)
         .filter(|slug| !slug.is_empty());
@@ -116,41 +164,29 @@ pub async fn posts_index_handler(
                 "name": c.name,
                 "slug": c.slug,
                 "count": c.count,
-                "url": format!("{}?category={}", config.url_prefix, c.slug),
+                "url": category_url(&config.url_prefix, &c.slug),
                 "active": Some(c.slug.as_str()) == category_filter.as_deref(),
             })
         })
         .collect();
 
-    // Query-string suffix appended to pagination links to preserve the filter
-    let category_query = category_filter
-        .as_deref()
-        .map(|slug| format!("&category={}", slug))
-        .unwrap_or_default();
+    // Base URL for pagination links and og:url; the category form keeps the filter
+    let page_base = match category_filter.as_deref() {
+        Some(slug) => category_url(&config.url_prefix, slug),
+        None => config.url_prefix.clone(),
+    };
+    let page_base_for_og = page_base.clone();
+
+    let feed_url = match category_filter.as_deref() {
+        Some(slug) => format!("{}/feed.xml", category_url(&config.url_prefix, slug)),
+        None => format!("{}/feed.xml", config.url_prefix),
+    };
 
     let base_url = app_state.base_url().unwrap_or("http://localhost:8080");
 
     let page_title = match &active_category {
-        Some(name) => format!(
-            "{} – {}",
-            posts_name
-                .chars()
-                .next()
-                .unwrap()
-                .to_uppercase()
-                .to_string()
-                + &posts_name[1..],
-            name
-        ),
-        None => {
-            posts_name
-                .chars()
-                .next()
-                .unwrap()
-                .to_uppercase()
-                .to_string()
-                + &posts_name[1..]
-        }
+        Some(name) => format!("{} – {}", capitalize(&posts_name), name),
+        None => capitalize(&posts_name),
     };
     let meta_description = match &active_category {
         Some(name) => format!("Browse {} posts in {}", posts_name, name),
@@ -164,7 +200,9 @@ pub async fn posts_index_handler(
         "can_edit": root_permissions.can_edit_content,
         "categories": categories,
         "active_category": active_category,
-        "category_query": category_query,
+        "page_base": page_base,
+        "feed_url": feed_url.clone(),
+        "rss_feed_url": feed_url,
         "current_page": page,
         "total_pages": total_pages,
         "has_prev": page > 0,
@@ -176,7 +214,7 @@ pub async fn posts_index_handler(
         "meta_description": meta_description.clone(),
         "og_title": page_title,
         "og_description": meta_description,
-        "og_url": format!("{}{}", base_url, config.url_prefix),
+        "og_url": format!("{}{}", base_url, page_base_for_og),
         "og_type": "website",
     });
 
@@ -251,6 +289,7 @@ pub async fn post_detail_handler(
         "posts_name": posts_name,
         "url_prefix": config.url_prefix,
         "can_edit": permissions.can_edit_content,
+        "rss_feed_url": format!("{}/feed.xml", config.url_prefix),
         "base_url": base_url,
         "page_title": post.title.clone(),
         "meta_description": post.summary.clone(),
@@ -276,6 +315,145 @@ pub async fn post_detail_handler(
             error!("Template rendering error: {}", e);
             ApiResponse::TemplateRenderError.into_response()
         }
+    }
+}
+
+/// Number of items included in RSS feeds
+const FEED_ITEM_LIMIT: usize = 20;
+
+pub async fn posts_feed_handler(
+    ResolvedState(app_state): ResolvedState,
+    Path(posts_name): Path<String>,
+    auth: crate::login::OptionalAuth,
+) -> axum::response::Response {
+    render_posts_feed(app_state, posts_name, None, auth.username()).await
+}
+
+pub async fn posts_category_feed_handler(
+    ResolvedState(app_state): ResolvedState,
+    Path((posts_name, category)): Path<(String, String)>,
+    auth: crate::login::OptionalAuth,
+) -> axum::response::Response {
+    render_posts_feed(app_state, posts_name, Some(category), auth.username()).await
+}
+
+async fn render_posts_feed(
+    app_state: crate::AppState,
+    posts_name: String,
+    category: Option<String>,
+    username: Option<&str>,
+) -> axum::response::Response {
+    use crate::sitemap::xml_escape;
+
+    let posts_manager = match app_state.posts_managers().get(&posts_name) {
+        Some(manager) => manager,
+        None => return ApiResponse::NotFound.into_response(),
+    };
+    let config = posts_manager.get_config();
+
+    let category_slug = category
+        .as_deref()
+        .map(PostsManager::category_slug)
+        .filter(|slug| !slug.is_empty());
+
+    // A category feed for an unknown category is a 404, not an empty feed
+    let category_name = match category_slug.as_deref() {
+        Some(slug) => {
+            let categories = posts_manager.get_categories(username).await;
+            match categories.into_iter().find(|c| c.slug == slug) {
+                Some(c) => Some(c.name),
+                None => return ApiResponse::NotFound.into_response(),
+            }
+        }
+        None => None,
+    };
+
+    let posts = posts_manager
+        .get_recent_posts(FEED_ITEM_LIMIT, category_slug.as_deref(), username)
+        .await;
+
+    let base_url = app_state.base_url().unwrap_or("http://localhost:8080");
+    let site_title = app_state.template_engine().site_title();
+
+    let channel_path = match category_slug.as_deref() {
+        Some(slug) => category_url(&config.url_prefix, slug),
+        None => config.url_prefix.clone(),
+    };
+    let channel_link = format!("{}{}", base_url, channel_path);
+    let self_url = format!("{}/feed.xml", channel_link);
+
+    let channel_title = match &category_name {
+        Some(name) => format!("{} — {} — {}", site_title, capitalize(&posts_name), name),
+        None => format!("{} — {}", site_title, capitalize(&posts_name)),
+    };
+    let channel_description = match &category_name {
+        Some(name) => format!("{} posts in {}", posts_name, name),
+        None => format!("{} posts", posts_name),
+    };
+
+    let mut xml = String::with_capacity(4096);
+    xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    xml.push_str("<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\">\n");
+    xml.push_str("<channel>\n");
+    xml.push_str(&format!("<title>{}</title>\n", xml_escape(&channel_title)));
+    xml.push_str(&format!("<link>{}</link>\n", xml_escape(&channel_link)));
+    xml.push_str(&format!(
+        "<atom:link href=\"{}\" rel=\"self\" type=\"application/rss+xml\"/>\n",
+        xml_escape(&self_url)
+    ));
+    xml.push_str(&format!(
+        "<description>{}</description>\n",
+        xml_escape(&channel_description)
+    ));
+    if let Some(newest) = posts.first() {
+        xml.push_str(&format!(
+            "<lastBuildDate>{}</lastBuildDate>\n",
+            newest.date.to_rfc2822()
+        ));
+    }
+
+    for post in &posts {
+        let link = format!("{}{}/{}", base_url, config.url_prefix, post.slug);
+        xml.push_str("<item>\n");
+        xml.push_str(&format!("<title>{}</title>\n", xml_escape(&post.title)));
+        xml.push_str(&format!("<link>{}</link>\n", xml_escape(&link)));
+        xml.push_str(&format!(
+            "<guid isPermaLink=\"true\">{}</guid>\n",
+            xml_escape(&link)
+        ));
+        xml.push_str(&format!(
+            "<description>{}</description>\n",
+            xml_escape(&post.summary)
+        ));
+        xml.push_str(&format!("<pubDate>{}</pubDate>\n", post.date.to_rfc2822()));
+        for category in &post.categories {
+            xml.push_str(&format!("<category>{}</category>\n", xml_escape(category)));
+        }
+        xml.push_str(&format!(
+            "<content:encoded><![CDATA[{}]]></content:encoded>\n",
+            // CDATA cannot contain "]]>"; split any occurrence across sections
+            post.html_content.replace("]]>", "]]]]><![CDATA[>")
+        ));
+        xml.push_str("</item>\n");
+    }
+
+    xml.push_str("</channel>\n</rss>\n");
+
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            "application/rss+xml; charset=utf-8",
+        )],
+        xml,
+    )
+        .into_response()
+}
+
+fn capitalize(name: &str) -> String {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
     }
 }
 

--- a/tenrankai/src/posts/tests.rs
+++ b/tenrankai/src/posts/tests.rs
@@ -353,6 +353,32 @@ roles = ["owner"]
     }
 
     #[tokio::test]
+    async fn test_reserved_category_slug_posts_are_skipped() {
+        let temp_dir = TempDir::new().unwrap();
+        let posts_dir = temp_dir.path();
+
+        let post = r#"+++
+title = "Shadowed"
+summary = "Would be unreachable behind the category routes"
+date = "2024-06-01"
++++
+
+Content."#;
+
+        let category_dir = posts_dir.join("category");
+        fs::create_dir(&category_dir).unwrap();
+        fs::write(category_dir.join("shadowed.md"), post).unwrap();
+        fs::write(posts_dir.join("visible.md"), post).unwrap();
+
+        let storage: DynStorage = Arc::new(FilesystemStorage::new(posts_dir));
+        let manager = PostsManager::new(test_config(posts_dir), storage);
+        manager.refresh_posts().await.unwrap();
+
+        assert!(manager.get_post("category/shadowed").await.is_none());
+        assert_eq!(manager.get_posts_page(0, None, None).await.len(), 1);
+    }
+
+    #[tokio::test]
     async fn test_get_recent_posts() {
         let temp_dir = TempDir::new().unwrap();
         let posts_dir = temp_dir.path();

--- a/tenrankai/src/posts/tests.rs
+++ b/tenrankai/src/posts/tests.rs
@@ -336,6 +336,11 @@ roles = ["owner"]
         assert!(PostsManager::validate_slug("my-post").is_ok());
         assert!(PostsManager::validate_slug("2024/travel/my_post-2").is_ok());
 
+        // "category" is reserved for category index routes
+        assert!(PostsManager::validate_slug("category").is_err());
+        assert!(PostsManager::validate_slug("category/nested").is_err());
+        assert!(PostsManager::validate_slug("categories").is_ok());
+
         assert!(PostsManager::validate_slug("").is_err());
         assert!(PostsManager::validate_slug("/leading").is_err());
         assert!(PostsManager::validate_slug("trailing/").is_err());
@@ -345,6 +350,48 @@ roles = ["owner"]
         assert!(PostsManager::validate_slug("../escape").is_err());
         assert!(PostsManager::validate_slug("has space").is_err());
         assert!(PostsManager::validate_slug("dot.md").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_recent_posts() {
+        let temp_dir = TempDir::new().unwrap();
+        let posts_dir = temp_dir.path();
+
+        for i in 1..=5 {
+            let categories = if i % 2 == 0 {
+                r#"["Even"]"#
+            } else {
+                r#"["Odd"]"#
+            };
+            let content = format!(
+                r#"+++
+title = "Post {i}"
+summary = "Summary {i}"
+date = "2024-07-0{i}"
+categories = {categories}
++++
+
+Body {i}."#
+            );
+            fs::write(posts_dir.join(format!("post-{i}.md")), content).unwrap();
+        }
+
+        let storage: DynStorage = Arc::new(FilesystemStorage::new(posts_dir));
+        let manager = PostsManager::new(test_config(posts_dir), storage);
+        manager.refresh_posts().await.unwrap();
+
+        // Limited, newest first, with full content
+        let recent = manager.get_recent_posts(3, None, None).await;
+        assert_eq!(recent.len(), 3);
+        assert_eq!(recent[0].title, "Post 5");
+        assert_eq!(recent[2].title, "Post 3");
+        assert!(recent[0].html_content.contains("Body 5."));
+
+        // Category filtering
+        let even = manager.get_recent_posts(10, Some("even"), None).await;
+        assert_eq!(even.len(), 2);
+        assert_eq!(even[0].title, "Post 4");
+        assert_eq!(even[1].title, "Post 2");
     }
 
     #[tokio::test]

--- a/tenrankai/src/posts/types.rs
+++ b/tenrankai/src/posts/types.rs
@@ -18,6 +18,10 @@ pub struct Post {
     /// Resolved URL for the post's hero image (frontmatter or first image in content)
     #[serde(default)]
     pub hero_image: Option<String>,
+    /// True when the hero came from frontmatter (not derived from content),
+    /// so the detail page should render it above the post body
+    #[serde(default)]
+    pub hero_image_explicit: bool,
     #[serde(default)]
     pub reading_time_minutes: usize,
     #[serde(skip)]

--- a/tenrankai/src/sitemap.rs
+++ b/tenrankai/src/sitemap.rs
@@ -440,7 +440,7 @@ async fn collect_posts_urls(
 
 /// Percent-encode each `/`-separated segment of a path. Segments never contain
 /// `/`, so re-joining them is lossless.
-fn encode_path_segments(path: &str) -> String {
+pub(crate) fn encode_path_segments(path: &str) -> String {
     path.split('/')
         .map(|segment| urlencoding::encode(segment).into_owned())
         .collect::<Vec<_>>()

--- a/tenrankai/src/sitemap.rs
+++ b/tenrankai/src/sitemap.rs
@@ -419,6 +419,14 @@ async fn collect_posts_urls(
 
     urls.push(UrlEntry::new(format!("{base_url}{}", config.url_prefix)));
 
+    // Publicly visible category index pages
+    for category in manager.get_categories(None).await {
+        urls.push(UrlEntry::new(format!(
+            "{base_url}{}/category/{}",
+            config.url_prefix, category.slug
+        )));
+    }
+
     let total_pages = manager.get_total_pages(None, None).await;
     for page in 0..total_pages {
         for post in manager.get_posts_page(page, None, None).await {
@@ -473,7 +481,7 @@ fn render_sitemap_index(base_url: &str, chunks: &[(String, Vec<UrlEntry>)]) -> S
     out
 }
 
-fn xml_escape(input: &str) -> String {
+pub(crate) fn xml_escape(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for c in input.chars() {
         match c {

--- a/tenrankai/src/templating.rs
+++ b/tenrankai/src/templating.rs
@@ -318,6 +318,13 @@ impl TemplateEngine {
         self.site_title = site_title;
     }
 
+    /// The display title, with the same "Tenrankai" fallback templates see
+    pub fn site_title(&self) -> String {
+        self.site_title
+            .clone()
+            .unwrap_or_else(|| "Tenrankai".to_string())
+    }
+
     pub fn set_copyright_holder(&mut self, copyright_holder: Option<String>) {
         self.copyright_holder = copyright_holder;
     }

--- a/tenrankai/src/templating.rs
+++ b/tenrankai/src/templating.rs
@@ -494,10 +494,7 @@ impl TemplateEngine {
 
         // Add site identity for header/footer branding. `site_title` falls back
         // to "Tenrankai"; `copyright_holder` falls back to the resolved title.
-        let site_title = self
-            .site_title
-            .clone()
-            .unwrap_or_else(|| "Tenrankai".to_string());
+        let site_title = self.site_title();
         let copyright_holder = self
             .copyright_holder
             .clone()

--- a/tests/posts_integration.rs
+++ b/tests/posts_integration.rs
@@ -354,6 +354,13 @@ async fn test_posts_rss_feed() {
     let first = xml.find("Second Test Post").unwrap();
     let second = xml.find("First Test Post").unwrap();
     assert!(first < second);
+
+    // Auth-varying responses must not be mixed by shared caches
+    assert_eq!(response.headers().get("vary").unwrap(), "Cookie");
+    assert_eq!(
+        response.headers().get("cache-control").unwrap(),
+        "public, max-age=300"
+    );
 }
 
 #[tokio::test]
@@ -391,6 +398,22 @@ Rust content."#;
         "/blog/category/rust-systems"
     );
 
+    // Unrelated query parameters survive the redirect
+    let response = server
+        .get("/blog")
+        .add_query_param("utm_source", "newsletter")
+        .add_query_param("category", "Rust & Systems")
+        .await;
+    assert_eq!(response.status_code(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(
+        response.headers().get("location").unwrap(),
+        "/blog/category/rust-systems?utm_source=newsletter"
+    );
+
+    // Unknown categories 404 on the index page
+    let response = server.get("/blog/category/nonexistent").await;
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+
     // Per-category feed contains only matching posts
     let response = server.get("/blog/category/rust-systems/feed.xml").await;
     assert_eq!(response.status_code(), StatusCode::OK);
@@ -399,7 +422,38 @@ Rust content."#;
     assert!(!xml.contains("First Test Post"));
     assert!(xml.contains("<category>Rust &amp; Systems</category>"));
 
-    // Unknown category: 404 for both page-with-no-posts feed and index stays 200
+    // Unknown category feeds are 404
     let response = server.get("/blog/category/nonexistent/feed.xml").await;
     assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_feed_absolutizes_content_urls() {
+    let (_temp_dir, server) = setup_test_server_with_posts().await;
+
+    let blog_dir = _temp_dir.path().join("posts").join("blog");
+    let post_content = r#"+++
+title = "Relative Links"
+summary = "Post with root-relative content URLs"
+date = "2024-03-05"
++++
+
+![local image](/static/photo.jpg)
+
+[a page](/about) and [protocol-relative](//example.com/x) and [absolute](https://example.com/y)."#;
+    fs::write(blog_dir.join("relative-links.md"), post_content).unwrap();
+    server.post("/api/posts/blog/refresh").await;
+
+    let response = server.get("/blog/feed.xml").await;
+    let xml = response.text();
+
+    // Root-relative URLs become absolute inside content:encoded
+    assert!(xml.contains(r#"src="http://localhost:3000/static/photo.jpg""#));
+    assert!(xml.contains(r#"href="http://localhost:3000/about""#));
+    // Protocol-relative and absolute URLs are untouched
+    assert!(xml.contains(r#"href="//example.com/x""#));
+    assert!(xml.contains(r#"href="https://example.com/y""#));
+    // The HTML page still serves the original relative URLs
+    let page = server.get("/blog/relative-links").await.text();
+    assert!(page.contains(r#"src="/static/photo.jpg""#));
 }

--- a/tests/posts_integration.rs
+++ b/tests/posts_integration.rs
@@ -325,3 +325,81 @@ This is a tutorial in a subdirectory."#;
     assert!(html.contains("Rust Tutorial"));
     assert!(html.contains("This is a tutorial in a subdirectory"));
 }
+
+#[tokio::test]
+async fn test_posts_rss_feed() {
+    let (_temp_dir, server) = setup_test_server_with_posts().await;
+
+    let response = server.get("/blog/feed.xml").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    assert!(
+        response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("application/rss+xml")
+    );
+
+    let xml = response.text();
+    assert!(xml.starts_with("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+    assert!(xml.contains("<rss version=\"2.0\""));
+    assert!(xml.contains("<title>First Test Post</title>"));
+    assert!(xml.contains("<title>Second Test Post</title>"));
+    assert!(xml.contains("<link>http://localhost:3000/blog/first-post</link>"));
+    assert!(xml.contains("<description>This is the first test post</description>"));
+    assert!(xml.contains("<content:encoded><![CDATA["));
+    // Newest first
+    let first = xml.find("Second Test Post").unwrap();
+    let second = xml.find("First Test Post").unwrap();
+    assert!(first < second);
+}
+
+#[tokio::test]
+async fn test_category_pages_and_feeds() {
+    let (_temp_dir, server) = setup_test_server_with_posts().await;
+
+    // Add a categorized post and refresh
+    let blog_dir = _temp_dir.path().join("posts").join("blog");
+    let post_content = r#"+++
+title = "Rust Deep Dive"
+summary = "A post about Rust"
+date = "2024-03-01"
+categories = ["Rust & Systems"]
++++
+
+Rust content."#;
+    fs::write(blog_dir.join("rust-deep-dive.md"), post_content).unwrap();
+    server.post("/api/posts/blog/refresh").await;
+
+    // Category index page shows only matching posts
+    let response = server.get("/blog/category/rust-systems").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let html = response.text();
+    assert!(html.contains("Rust Deep Dive"));
+    assert!(!html.contains("First Test Post"));
+
+    // Legacy query-parameter URLs redirect permanently to the path form
+    let response = server
+        .get("/blog")
+        .add_query_param("category", "Rust & Systems")
+        .await;
+    assert_eq!(response.status_code(), StatusCode::PERMANENT_REDIRECT);
+    assert_eq!(
+        response.headers().get("location").unwrap(),
+        "/blog/category/rust-systems"
+    );
+
+    // Per-category feed contains only matching posts
+    let response = server.get("/blog/category/rust-systems/feed.xml").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let xml = response.text();
+    assert!(xml.contains("<title>Rust Deep Dive</title>"));
+    assert!(!xml.contains("First Test Post"));
+    assert!(xml.contains("<category>Rust &amp; Systems</category>"));
+
+    // Unknown category: 404 for both page-with-no-posts feed and index stays 200
+    let response = server.get("/blog/category/nonexistent/feed.xml").await;
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
## Summary

Follow-up revision to the posts revamp (#247):

### Path-style category URLs
- Category pages move from `/blog?category=<slug>` to **`/blog/category/<slug>`**; the legacy query form 301-redirects to the canonical path, preserving unrelated query parameters (e.g. `utm_*`).
- `category` is now a reserved path segment: the editor API rejects it for new slugs, and on-disk posts under a `category/` directory are skipped at load with a warning instead of being silently shadowed by the routes.
- Unknown categories 404 on both the index page and the feed.
- Publicly visible category pages are included in `sitemap.xml`.

### RSS feeds
- **`/blog/feed.xml`** (site-wide) and **`/blog/category/<slug>/feed.xml`** (per category), RSS 2.0 with `atom:link` self, categories, RFC 2822 dates, and full `content:encoded`.
- Permission-aware: restricted posts appear only in authenticated fetches, and responses carry `Vary: Cookie` plus appropriate `Cache-Control` so shared caches never leak authenticated copies.
- Root-relative image/link URLs inside `content:encoded` are rewritten to absolute so posts render correctly in feed readers; item links percent-encode slug segments.
- Feed discovery via `<link rel="alternate">` on index/detail pages and a visible RSS chip in the category filter bar.

### UI fixes (reported during review)
- An explicit `hero_image` from frontmatter now renders above the post body on the detail page (heroes derived from the first content image are not duplicated).
- Post index cards are fully clickable via a stretched title link; category labels inside a card remain independently clickable.

### Review
A high-effort multi-agent review of the initial cut surfaced 6 correctness issues (cache-poisoning risk on auth-varying feeds, route shadowing of `category/` slugs, relative URLs in feeds, redirect dropping query params, unencoded feed URIs, 404-inconsistency between page and feed) — all fixed here with regression tests, plus four deduplication cleanups.

## Testing
- 470 Rust tests (new: reserved-slug skip, `get_recent_posts`, feed XML/headers, redirect param preservation, content absolutization)
- 31 Playwright tests (new: path URLs, redirects, global/category/permission-filtered feeds, hero rendering, clickable cards)
- `cargo clippy -D warnings`, `cargo fmt --check`, `npm run lint`, `npm test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)