### PR TITLE
Move RSS link to page footer; richer article Open Graph metadata

### DIFF
--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -32,16 +32,27 @@ test.describe('posts index', () => {
     await page.goto('/blog');
 
     const chips = page.locator('.category-bar .category-chip');
-    await expect(chips).toHaveCount(4); // All, Gear, Travel, RSS
+    await expect(chips).toHaveCount(3); // All, Gear, Travel
     await expect(chips.nth(0)).toHaveText('All');
     await expect(chips.nth(0)).toHaveClass(/active/);
     await expect(chips.nth(1)).toContainText('Gear');
     await expect(chips.nth(1).locator('.category-count')).toHaveText('2');
     await expect(chips.nth(2)).toContainText('Travel');
     await expect(chips.nth(2).locator('.category-count')).toHaveText('2');
+  });
 
-    const rss = page.locator('.category-bar .feed-chip');
-    expect(await rss.getAttribute('href')).toBe('/blog/feed.xml');
+  test('shows a subscribe link at the bottom of the page', async ({ page }) => {
+    await page.goto('/blog');
+    const link = page.locator('.posts-feed-footer .posts-feed-link');
+    await expect(link).toBeVisible();
+    await expect(link).toContainText('Subscribe via RSS');
+    expect(await link.getAttribute('href')).toBe('/blog/feed.xml');
+
+    // On a category page the link targets the category feed
+    await page.goto('/blog/category/gear');
+    const categoryLink = page.locator('.posts-feed-footer .posts-feed-link');
+    await expect(categoryLink).toContainText('Gear');
+    expect(await categoryLink.getAttribute('href')).toBe('/blog/category/gear/feed.xml');
   });
 
   test('renders hero images from gallery references', async ({ page }) => {
@@ -180,6 +191,30 @@ test.describe('post detail', () => {
     await expect(ogImage).toHaveAttribute('content', /localhost:4319\/g\/_image\//);
     const ogUrl = page.locator('meta[property="og:url"]');
     await expect(ogUrl).toHaveAttribute('content', 'http://localhost:4319/blog/first-trip');
+
+    // Article namespace metadata, including categories
+    await expect(page.locator('meta[property="article:published_time"]')).toHaveAttribute(
+      'content',
+      /^2024-01-01T/,
+    );
+    await expect(page.locator('meta[property="article:modified_time"]')).toHaveCount(1);
+    await expect(page.locator('meta[property="article:section"]')).toHaveAttribute(
+      'content',
+      'Travel',
+    );
+    await expect(page.locator('meta[property="article:tag"]')).toHaveAttribute(
+      'content',
+      'Travel',
+    );
+    await expect(page.locator('meta[property="article:author"]')).toHaveCount(1);
+
+    // Multi-category posts emit one article:tag per category
+    await page.goto('/blog/second-trip');
+    await expect(page.locator('meta[property="article:tag"]')).toHaveCount(2);
+    await expect(page.locator('meta[property="article:section"]')).toHaveAttribute(
+      'content',
+      'Travel',
+    );
   });
 
   test('omits og:image when the post has no images', async ({ page }) => {

--- a/static/posts-index.css
+++ b/static/posts-index.css
@@ -238,3 +238,32 @@
     font-size: 0.9rem;
     font-weight: normal;
 }
+
+/* Feed subscribe footer */
+
+.posts-feed-footer {
+    display: flex;
+    justify-content: center;
+    margin: var(--spacing-xxl) 0 var(--spacing-md) 0;
+    padding-top: var(--spacing-lg);
+    border-top: 1px solid var(--border-color);
+}
+
+.posts-feed-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.posts-feed-link:hover {
+    color: var(--text-primary);
+    border-color: var(--border-hover);
+    background-color: var(--bg-hover);
+}

--- a/templates/modules/posts_index.html.liquid
+++ b/templates/modules/posts_index.html.liquid
@@ -14,7 +14,7 @@
         {% endif %}
     </header>
 
-    {% if posts.size > 0 or categories.size > 0 %}
+    {% if categories.size > 0 %}
     <nav class="category-bar" aria-label="Post categories">
         <a href="{{ url_prefix }}" class="category-chip{% unless active_category %} active{% endunless %}">All</a>
         {% for category in categories %}
@@ -22,10 +22,6 @@
             {{ category.name }}<span class="category-count">{{ category.count }}</span>
         </a>
         {% endfor %}
-        <a href="{{ rss_feed_url }}" class="category-chip feed-chip" title="RSS feed">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 20.82a2.18 2.18 0 1 1-4.36 0 2.18 2.18 0 0 1 4.36 0zM1.82 8.91v3.05c5.65 0 10.22 4.57 10.22 10.22h3.05c0-7.33-5.94-13.27-13.27-13.27zm0-6.09v3.05c9.01 0 16.31 7.3 16.31 16.31h3.05C21.18 11.5 12.5 2.82 1.82 2.82z"/></svg>
-            RSS
-        </a>
     </nav>
     {% endif %}
 
@@ -77,6 +73,13 @@
     {% else %}
         <p class="posts-empty">No posts found{% if active_category %} in {{ active_category }}{% endif %}.</p>
     {% endif %}
+
+    <footer class="posts-feed-footer">
+        <a href="{{ rss_feed_url }}" class="posts-feed-link" title="RSS feed">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 20.82a2.18 2.18 0 1 1-4.36 0 2.18 2.18 0 0 1 4.36 0zM1.82 8.91v3.05c5.65 0 10.22 4.57 10.22 10.22h3.05c0-7.33-5.94-13.27-13.27-13.27zm0-6.09v3.05c9.01 0 16.31 7.3 16.31 16.31h3.05C21.18 11.5 12.5 2.82 1.82 2.82z"/></svg>
+            Subscribe via RSS{% if active_category %} — {{ active_category }}{% endif %}
+        </a>
+    </footer>
 </div>
 
 {% include "_footer.html.liquid" %}

--- a/templates/partials/_header.html.liquid
+++ b/templates/partials/_header.html.liquid
@@ -34,6 +34,27 @@
     {% endif %}
     <meta property="og:site_name" content="{{ site_title }}">
     
+    {% comment %} Article meta tags (posts) {% endcomment %}
+    {% if og_type == "article" %}
+    {% if article_published_time %}
+    <meta property="article:published_time" content="{{ article_published_time }}">
+    {% endif %}
+    {% if article_modified_time %}
+    <meta property="article:modified_time" content="{{ article_modified_time }}">
+    {% endif %}
+    {% if article_author %}
+    <meta property="article:author" content="{{ article_author }}">
+    {% endif %}
+    {% if article_section %}
+    <meta property="article:section" content="{{ article_section }}">
+    {% endif %}
+    {% if article_tags %}
+    {% for tag in article_tags %}
+    <meta property="article:tag" content="{{ tag }}">
+    {% endfor %}
+    {% endif %}
+    {% endif %}
+
     {% comment %} Twitter Card meta tags {% endcomment %}
     <meta name="twitter:card" content="{% if twitter_card_type %}{{ twitter_card_type }}{% else %}summary_large_image{% endif %}">
     {% if twitter_title %}

--- a/tenrankai/src/posts/handlers.rs
+++ b/tenrankai/src/posts/handlers.rs
@@ -292,6 +292,11 @@ pub async fn post_detail_handler(
         }
     });
 
+    let article_modified_time = post
+        .last_modified
+        .map(|time| chrono::DateTime::<chrono::Utc>::from(time).to_rfc3339());
+    let article_section = post.categories.first().cloned();
+
     let globals = liquid::object!({
         "post": {
             "slug": post.slug,
@@ -322,6 +327,10 @@ pub async fn post_detail_handler(
         "twitter_description": post.summary,
         "twitter_image": og_image,
         "article_published_time": post.date.to_rfc3339(),
+        "article_modified_time": article_modified_time,
+        "article_author": app_state.template_engine().copyright_holder(),
+        "article_section": article_section,
+        "article_tags": post.categories,
         "share_url": full_url,
     });
 

--- a/tenrankai/src/templating.rs
+++ b/tenrankai/src/templating.rs
@@ -325,6 +325,13 @@ impl TemplateEngine {
             .unwrap_or_else(|| "Tenrankai".to_string())
     }
 
+    /// The copyright holder, falling back to the site title like templates do
+    pub fn copyright_holder(&self) -> String {
+        self.copyright_holder
+            .clone()
+            .unwrap_or_else(|| self.site_title())
+    }
+
     pub fn set_copyright_holder(&mut self, copyright_holder: Option<String>) {
         self.copyright_holder = copyright_holder;
     }
@@ -513,6 +520,12 @@ impl TemplateEngine {
             "has_user_auth".into(),
             liquid::model::Value::scalar(self.has_user_auth),
         );
+
+        // Default og:type so templates can compare it without guarding
+        // against an undefined variable
+        if !globals.contains_key("og_type") {
+            globals.insert("og_type".into(), liquid::model::Value::scalar("website"));
+        }
 
         // Add force color scheme (if set)
         if let Some(ref scheme) = self.force_color_scheme {


### PR DESCRIPTION
## Summary

- **RSS placement**: the subscribe link moves out of the category filter bar to a dedicated footer at the bottom of the posts index. On category pages it targets the category feed and is labeled with the category name.
- **Richer Open Graph for posts**: post pages now emit the full `article:*` namespace — `article:published_time`, `article:modified_time` (from the file's mtime), `article:author` (copyright holder), `article:section` (first category), and one `article:tag` per category. The previously-passed `article_published_time` global was never rendered by the header; now it is.
- **`og_type` injected everywhere**: the template engine defaults `og_type` to `"website"` for every render (handlers can override), so templates can compare it directly. Comparing an undefined variable is a Liquid render error — this bit us on gallery/auth pages during rollout.

## Testing
- 470 Rust tests, 32 Playwright tests (new: subscribe footer placement/labeling, article meta assertions incl. multi-category tags), clippy/fmt/lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)