### PR TITLE
Fix posts heading overlapping the site header when scrolling

### DIFF
--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -145,6 +145,25 @@ test.describe('posts index', () => {
     expect(response?.status()).toBe(404);
   });
 
+  test('page heading does not become a second sticky header', async ({ page }) => {
+    await page.goto('/blog');
+    // The global site-chrome header rule must not leak onto .posts-header
+    const position = await page
+      .locator('.posts-header')
+      .evaluate((el) => getComputedStyle(el).position);
+    expect(position).toBe('static');
+
+    // After scrolling, only the site header occupies the top of the viewport
+    await page.mouse.wheel(0, 600);
+    await page.waitForTimeout(200);
+    const topElement = await page.evaluate(() => {
+      const el = document.elementsFromPoint(window.innerWidth / 2, 20)[0];
+      return el?.closest('body > header') ? 'site-header' : (el?.className || el?.tagName);
+    });
+    expect(topElement).toBe('site-header');
+    await shot(page, 'posts-index-scrolled');
+  });
+
   test('whole card is clickable', async ({ page }) => {
     await page.goto('/blog');
     // Click the summary text, not the title link. The stretched link overlays

--- a/static/style.css
+++ b/static/style.css
@@ -240,7 +240,7 @@ h1, h2, h3, h4, h5, h6 {
     font-family: var(--font-heading);
 }
 
-header {
+body > header {
     background-color: var(--header-bg);
     color: var(--text-primary);
     padding: 0.5rem 0;
@@ -331,7 +331,7 @@ main {
     color: var(--text-primary);
 }
 
-footer {
+body > footer {
     background-color: var(--bg-primary);
     color: var(--text-secondary);
     text-align: left;
@@ -339,7 +339,7 @@ footer {
     margin-top: auto;
 }
 
-footer p {
+body > footer p {
     margin: 0;
     font-size: 0.875rem;
 }
@@ -868,7 +868,7 @@ footer p {
         margin: 0 auto;
     }
 
-    footer {
+    body > footer {
         padding: 1rem 0.5rem;
     }
 


### PR DESCRIPTION
## Summary

Scrolling any posts index (e.g. theatr.us/projects) made the page heading overlap the site navigation bar. Root cause: `style.css` styles the site chrome with bare element selectors — `header { position: sticky; top: 0; z-index: 1000; ... }` — which also matched the semantic `<header class="posts-header">` introduced by the posts revamp, turning the page heading into a second sticky bar that painted over the nav. The global `footer` rule similarly leaked background/padding into `<footer>` elements on post pages.

Fix: scope the chrome rules to `body > header` / `body > footer` (the only bare header/footer elements across the stock, tenrankai.com, and theatr.us template sets are the site chrome, direct children of `<body>`).

The global `nav` element rules also leak into `.category-bar`/`.breadcrumbs`, but gallery pages currently depend on that styling, so it is intentionally left out of this fix.

## Testing
- New Playwright regression test: asserts `.posts-header` is not position-sticky and that after scrolling, the element at the top of the viewport is the site header.
- Full suite: 33 Playwright tests green, stylelint/css-vars green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)