### PR TITLE
Category options: archive categories, descriptions, display names, and ordering

### DIFF
--- a/e2e/fixtures/posts/_categories.md
+++ b/e2e/fixtures/posts/_categories.md
@@ -1,0 +1,6 @@
++++
+[categories.archive]
+name = "Archive"
+description = "Older posts kept for reference"
+archive = true
++++

--- a/e2e/fixtures/posts/old-archived.md
+++ b/e2e/fixtures/posts/old-archived.md
@@ -1,0 +1,10 @@
++++
+title = "Old Archived Note"
+summary = "An archived post hidden from the main index."
+date = "2023-12-30"
+categories = ["Archive"]
++++
+
+# Old Archived Note
+
+This post is archived and only appears in the Archive category view.

--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -2,10 +2,12 @@ import { test, expect } from '@playwright/test';
 import { shot } from './helpers';
 
 // Fixture posts (e2e/fixtures/posts), newest first:
-//   Plain Note   2024-01-04  (no categories)
-//   Camera Bag   2024-01-03  (Gear, hero from first content image)
-//   Second Trip  2024-01-02  (Travel, Gear)
-//   First Trip   2024-01-01  (Travel, explicit gallery hero)
+//   Plain Note         2024-01-04  (no categories)
+//   Camera Bag         2024-01-03  (Gear, hero from first content image)
+//   Second Trip        2024-01-02  (Travel, Gear)
+//   First Trip         2024-01-01  (Travel, explicit gallery hero)
+//   Old Archived Note  2023-12-30  (Archive — declared archive=true in _categories.md,
+//                                   hidden from the unfiltered index and main feed)
 // posts_per_page = 3, so the unfiltered index has two pages.
 
 test.describe('posts index', () => {
@@ -32,13 +34,49 @@ test.describe('posts index', () => {
     await page.goto('/blog');
 
     const chips = page.locator('.category-bar .category-chip');
-    await expect(chips).toHaveCount(3); // All, Gear, Travel
+    await expect(chips).toHaveCount(4); // All, Gear, Travel, Archive
     await expect(chips.nth(0)).toHaveText('All');
     await expect(chips.nth(0)).toHaveClass(/active/);
     await expect(chips.nth(1)).toContainText('Gear');
     await expect(chips.nth(1).locator('.category-count')).toHaveText('2');
     await expect(chips.nth(2)).toContainText('Travel');
     await expect(chips.nth(2).locator('.category-count')).toHaveText('2');
+
+    // The archive chip renders last, after a separator
+    await expect(chips.nth(3)).toContainText('Archive');
+    await expect(chips.nth(3)).toHaveClass(/archive/);
+    await expect(page.locator('.category-bar-separator')).toHaveCount(1);
+  });
+
+  test('archive categories hide posts from the main flow', async ({ page }) => {
+    // Archived posts are absent from both pages of the unfiltered index
+    await page.goto('/blog');
+    await expect(page.locator('.post-card', { hasText: 'Old Archived Note' })).toHaveCount(0);
+    await expect(page.locator('.posts-pagination .page-info')).toHaveText('Page 1 of 2');
+    await page.goto('/blog?page=1');
+    await expect(page.locator('.post-card', { hasText: 'Old Archived Note' })).toHaveCount(0);
+
+    // ...and from the main feed
+    const feed = await page.request.get('/blog/feed.xml');
+    expect(await feed.text()).not.toContain('Old Archived Note');
+
+    // The archive category page is the archive view, with its declared description
+    await page.goto('/blog');
+    await page.locator('.category-bar .category-chip.archive').click();
+    await expect(page).toHaveURL(/\/blog\/category\/archive$/);
+    await expect(page.locator('.post-card h2')).toHaveText('Old Archived Note');
+    await expect(page.locator('.posts-category-description')).toHaveText(
+      'Older posts kept for reference',
+    );
+    await shot(page, 'posts-archive-category');
+
+    // Archived posts stay reachable at their permalinks and in their feed
+    const post = await page.request.get('/blog/old-archived');
+    expect(post.status()).toBe(200);
+    const archiveFeed = await page.request.get('/blog/category/archive/feed.xml');
+    const xml = await archiveFeed.text();
+    expect(xml).toContain('<title>Old Archived Note</title>');
+    expect(xml).toContain('<description>Older posts kept for reference</description>');
   });
 
   test('shows a subscribe link at the bottom of the page', async ({ page }) => {

--- a/static/posts-index.css
+++ b/static/posts-index.css
@@ -31,6 +31,12 @@
     color: var(--link-color);
 }
 
+.posts-category-description {
+    margin: var(--spacing-xs) 0 0 0;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
 .posts-empty {
     color: var(--text-secondary);
     margin: var(--spacing-xxl) 0;
@@ -75,6 +81,22 @@
 .category-count {
     font-size: 0.75rem;
     opacity: 0.75;
+}
+
+.category-bar-separator {
+    width: 1px;
+    align-self: stretch;
+    margin: 0 var(--spacing-xs);
+    background-color: var(--border-color);
+}
+
+.category-chip.archive {
+    border-style: dashed;
+    opacity: 0.8;
+}
+
+.category-chip.archive.active {
+    opacity: 1;
 }
 
 /* Flowing post card layout */

--- a/templates/modules/posts_index.html.liquid
+++ b/templates/modules/posts_index.html.liquid
@@ -11,17 +11,30 @@
         </div>
         {% if active_category %}
         <p class="posts-filter-note">Showing posts in <strong>{{ active_category }}</strong> — <a href="{{ url_prefix }}">show all</a></p>
+        {% if active_category_description %}
+        <p class="posts-category-description">{{ active_category_description }}</p>
+        {% endif %}
         {% endif %}
     </header>
 
     {% if categories.size > 0 %}
+    {% assign has_archive = false %}
+    {% for category in categories %}{% if category.archive %}{% assign has_archive = true %}{% endif %}{% endfor %}
     <nav class="category-bar" aria-label="Post categories">
         <a href="{{ url_prefix }}" class="category-chip{% unless active_category %} active{% endunless %}">All</a>
-        {% for category in categories %}
+        {% for category in categories %}{% unless category.archive %}
         <a href="{{ category.url }}" class="category-chip{% if category.active %} active{% endif %}">
             {{ category.name }}<span class="category-count">{{ category.count }}</span>
         </a>
-        {% endfor %}
+        {% endunless %}{% endfor %}
+        {% if has_archive %}
+        <span class="category-bar-separator" aria-hidden="true"></span>
+        {% for category in categories %}{% if category.archive %}
+        <a href="{{ category.url }}" class="category-chip archive{% if category.active %} active{% endif %}">
+            {{ category.name }}<span class="category-count">{{ category.count }}</span>
+        </a>
+        {% endif %}{% endfor %}
+        {% endif %}
     </nav>
     {% endif %}
 

--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -18,6 +18,8 @@ pub struct PostsManager {
     /// Per-directory permission overrides from _folder.md files, keyed by
     /// directory path relative to the posts root ("" for the root)
     folder_permissions: Arc<RwLock<HashMap<String, PermissionConfig>>>,
+    /// Per-category options from _categories.md at the posts root, keyed by slug
+    category_options: Arc<RwLock<HashMap<String, CategoryOptions>>>,
     galleries: Option<Arc<HashMap<String, SharedGallery>>>,
 }
 
@@ -29,6 +31,7 @@ impl PostsManager {
             posts: Arc::new(RwLock::new(HashMap::new())),
             sorted_slugs: Arc::new(RwLock::new(Vec::new())),
             folder_permissions: Arc::new(RwLock::new(HashMap::new())),
+            category_options: Arc::new(RwLock::new(HashMap::new())),
             galleries: None,
         }
     }
@@ -46,6 +49,7 @@ impl PostsManager {
 
         let mut new_posts = HashMap::new();
         let mut new_folder_permissions = HashMap::new();
+        let mut new_category_options = HashMap::new();
 
         // List all files recursively from storage
         let entries = self.storage.list_recursive("").await?;
@@ -77,6 +81,20 @@ impl PostsManager {
                 continue;
             }
             if file_name.starts_with('_') {
+                // Category definitions live only at the posts root
+                if entry.path == "_categories.md" {
+                    match self.load_category_options(&entry.path).await {
+                        Ok(options) => new_category_options = options,
+                        Err(e) => {
+                            error!("Failed to load category options {}: {}", entry.path, e);
+                        }
+                    }
+                } else if file_name == "_categories.md" {
+                    warn!(
+                        "Ignoring {}: _categories.md is only read at the posts root",
+                        entry.path
+                    );
+                }
                 continue;
             }
 
@@ -114,11 +132,54 @@ impl PostsManager {
         let mut posts = self.posts.write().await;
         let mut slugs = self.sorted_slugs.write().await;
         let mut folder_perms = self.folder_permissions.write().await;
+        let mut category_options = self.category_options.write().await;
         *posts = new_posts;
         *slugs = sorted_slugs;
         *folder_perms = new_folder_permissions;
+        *category_options = new_category_options;
 
         Ok(())
+    }
+
+    /// Parse the [categories] tables from _categories.md TOML frontmatter,
+    /// normalizing keys to slugs
+    async fn load_category_options(
+        &self,
+        path: &str,
+    ) -> Result<HashMap<String, CategoryOptions>, PostsError> {
+        let content = self.storage.read_to_string(path).await?;
+
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        if parts.len() < 3 || !parts[0].trim().is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        #[derive(Deserialize)]
+        struct CategoriesFrontMatter {
+            #[serde(default)]
+            categories: HashMap<String, CategoryOptions>,
+        }
+
+        let front_matter: CategoriesFrontMatter = toml_edit::de::from_str(parts[1])?;
+        let mut options = HashMap::new();
+        for (key, value) in front_matter.categories {
+            let slug = Self::category_slug(&key);
+            if slug.is_empty() {
+                warn!("Ignoring category definition with empty slug: {:?}", key);
+                continue;
+            }
+            options.insert(slug, value);
+        }
+        Ok(options)
+    }
+
+    /// A post is archived when any of its categories is flagged `archive`
+    fn is_archived(options: &HashMap<String, CategoryOptions>, post: &Post) -> bool {
+        post.categories.iter().any(|c| {
+            options
+                .get(&Self::category_slug(c))
+                .is_some_and(|o| o.archive)
+        })
     }
 
     /// Parse the [permissions] table from a _folder.md file's TOML frontmatter
@@ -351,7 +412,8 @@ impl PostsManager {
     }
 
     /// Posts visible to the user (newest first), optionally filtered by
-    /// category, windowed by skip/limit
+    /// category, windowed by skip/limit. The unfiltered view excludes
+    /// archived posts; category views list everything in the category.
     async fn visible_posts(
         &self,
         category: Option<&str>,
@@ -362,17 +424,32 @@ impl PostsManager {
         let posts = self.posts.read().await;
         let slugs = self.sorted_slugs.read().await;
         let folder_perms = self.folder_permissions.read().await;
+        let options = self.category_options.read().await;
         let mut visibility = HashMap::new();
 
         slugs
             .iter()
             .filter_map(|slug| posts.get(slug))
             .filter(|post| Self::matches_category(post, category))
+            .filter(|post| category.is_some() || !Self::is_archived(&options, post))
             .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, username))
             .skip(skip)
             .take(limit)
             .cloned()
             .collect()
+    }
+
+    fn summarize(&self, post: Post) -> PostSummary {
+        PostSummary {
+            url: format!("{}/{}", self.config.url_prefix, post.slug),
+            slug: post.slug,
+            title: post.title,
+            summary: post.summary,
+            date: post.date,
+            categories: post.categories,
+            hero_image: post.hero_image,
+            reading_time_minutes: post.reading_time_minutes,
+        }
     }
 
     pub async fn get_posts_page(
@@ -386,16 +463,24 @@ impl PostsManager {
         self.visible_posts(category, username, start, self.config.posts_per_page)
             .await
             .into_iter()
-            .map(|post| PostSummary {
-                url: format!("{}/{}", self.config.url_prefix, post.slug),
-                slug: post.slug,
-                title: post.title,
-                summary: post.summary,
-                date: post.date,
-                categories: post.categories,
-                hero_image: post.hero_image,
-                reading_time_minutes: post.reading_time_minutes,
-            })
+            .map(|post| self.summarize(post))
+            .collect()
+    }
+
+    /// All posts visible to anonymous users, newest first, including archived
+    /// posts — the sitemap lists archived permalinks even though the
+    /// unfiltered index hides them
+    pub async fn get_public_post_summaries(&self) -> Vec<PostSummary> {
+        let posts = self.posts.read().await;
+        let slugs = self.sorted_slugs.read().await;
+        let folder_perms = self.folder_permissions.read().await;
+        let mut visibility = HashMap::new();
+
+        slugs
+            .iter()
+            .filter_map(|slug| posts.get(slug))
+            .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, None))
+            .map(|post| self.summarize(post.clone()))
             .collect()
     }
 
@@ -446,10 +531,12 @@ impl PostsManager {
     }
 
     /// All categories across posts visible to the user, with display label,
-    /// slug, and post count, sorted alphabetically by label
+    /// slug, post count, and any options declared in _categories.md. Sorted
+    /// by declared weight then label, with archive categories last.
     pub async fn get_categories(&self, username: Option<&str>) -> Vec<CategoryInfo> {
         let posts = self.posts.read().await;
         let folder_perms = self.folder_permissions.read().await;
+        let options = self.category_options.read().await;
         let mut visibility = HashMap::new();
 
         let mut categories: HashMap<String, CategoryInfo> = HashMap::new();
@@ -464,18 +551,42 @@ impl PostsManager {
                 }
                 categories
                     .entry(slug.clone())
-                    .or_insert_with(|| CategoryInfo {
-                        name: name.clone(),
-                        slug,
-                        count: 0,
+                    .or_insert_with(|| {
+                        let opts = options.get(&slug);
+                        CategoryInfo {
+                            name: opts
+                                .and_then(|o| o.name.clone())
+                                .unwrap_or_else(|| name.clone()),
+                            slug,
+                            count: 0,
+                            description: opts.and_then(|o| o.description.clone()),
+                            archive: opts.is_some_and(|o| o.archive),
+                        }
                     })
                     .count += 1;
             }
         }
 
         let mut result: Vec<CategoryInfo> = categories.into_values().collect();
-        result.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        result.sort_by(|a, b| {
+            let weight = |c: &CategoryInfo| {
+                options
+                    .get(&c.slug)
+                    .and_then(|o| o.weight)
+                    .unwrap_or(i64::MAX)
+            };
+            (a.archive, weight(a), a.name.to_lowercase()).cmp(&(
+                b.archive,
+                weight(b),
+                b.name.to_lowercase(),
+            ))
+        });
         result
+    }
+
+    /// Options declared for a category slug in _categories.md, if any
+    pub async fn get_category_options(&self, slug: &str) -> Option<CategoryOptions> {
+        self.category_options.read().await.get(slug).cloned()
     }
 
     pub async fn get_post(&self, slug: &str) -> Option<Post> {
@@ -536,11 +647,13 @@ impl PostsManager {
     pub async fn get_total_pages(&self, category: Option<&str>, username: Option<&str>) -> usize {
         let posts = self.posts.read().await;
         let folder_perms = self.folder_permissions.read().await;
+        let options = self.category_options.read().await;
         let mut visibility = HashMap::new();
 
         let count = posts
             .values()
             .filter(|post| Self::matches_category(post, category))
+            .filter(|post| category.is_some() || !Self::is_archived(&options, post))
             .filter(|post| self.dir_visible(&folder_perms, &mut visibility, &post.slug, username))
             .count();
         count.div_ceil(self.config.posts_per_page)

--- a/tenrankai/src/posts/handlers.rs
+++ b/tenrankai/src/posts/handlers.rs
@@ -168,18 +168,18 @@ async fn render_posts_index(
         .await;
 
     let all_categories = posts_manager.get_categories(username).await;
-    let active_category = category_filter.as_deref().and_then(|slug| {
-        all_categories
-            .iter()
-            .find(|c| c.slug == slug)
-            .map(|c| c.name.clone())
-    });
+    let active = category_filter
+        .as_deref()
+        .and_then(|slug| all_categories.iter().find(|c| c.slug == slug));
 
     // A category page for a category with no visible posts is a 404, matching
     // the feed handler
-    if category_filter.is_some() && active_category.is_none() {
+    if category_filter.is_some() && active.is_none() {
         return ApiResponse::PostNotFound.into_response();
     }
+
+    let active_category = active.map(|c| c.name.clone());
+    let active_category_description = active.and_then(|c| c.description.clone());
 
     let categories: Vec<_> = all_categories
         .iter()
@@ -188,6 +188,8 @@ async fn render_posts_index(
                 "name": c.name,
                 "slug": c.slug,
                 "count": c.count,
+                "archive": c.archive,
+                "description": c.description,
                 "url": category_url(&config.url_prefix, &c.slug),
                 "active": Some(c.slug.as_str()) == category_filter.as_deref(),
             })
@@ -208,9 +210,10 @@ async fn render_posts_index(
         Some(name) => format!("{} – {}", capitalize(&posts_name), name),
         None => capitalize(&posts_name),
     };
-    let meta_description = match &active_category {
-        Some(name) => format!("Browse {} posts in {}", posts_name, name),
-        None => format!("Browse {} posts", posts_name),
+    let meta_description = match (&active_category_description, &active_category) {
+        (Some(description), _) => description.clone(),
+        (None, Some(name)) => format!("Browse {} posts in {}", posts_name, name),
+        (None, None) => format!("Browse {} posts", posts_name),
     };
 
     let globals = liquid::object!({
@@ -220,6 +223,7 @@ async fn render_posts_index(
         "can_edit": root_permissions.can_edit_content,
         "categories": categories,
         "active_category": active_category,
+        "active_category_description": active_category_description,
         "page_base": page_base,
         "rss_feed_url": feed_url,
         "current_page": page,
@@ -390,7 +394,12 @@ async fn render_posts_feed(
         .await;
 
     // A category feed for a category with no visible posts is a 404, not an
-    // empty feed; the display name comes from the matching label
+    // empty feed; the display name comes from _categories.md when declared,
+    // otherwise from the matching label
+    let category_options = match category_slug.as_deref() {
+        Some(slug) => posts_manager.get_category_options(slug).await,
+        None => None,
+    };
     let category_name = match category_slug.as_deref() {
         Some(slug) => {
             let name = posts.first().and_then(|post| {
@@ -400,7 +409,12 @@ async fn render_posts_feed(
                     .cloned()
             });
             match name {
-                Some(name) => Some(name),
+                Some(name) => Some(
+                    category_options
+                        .as_ref()
+                        .and_then(|o| o.name.clone())
+                        .unwrap_or(name),
+                ),
                 None => return ApiResponse::NotFound.into_response(),
             }
         }
@@ -421,9 +435,13 @@ async fn render_posts_feed(
         Some(name) => format!("{} — {} — {}", site_title, capitalize(&posts_name), name),
         None => format!("{} — {}", site_title, capitalize(&posts_name)),
     };
-    let channel_description = match &category_name {
-        Some(name) => format!("{} posts in {}", posts_name, name),
-        None => format!("{} posts", posts_name),
+    let declared_description = category_options
+        .as_ref()
+        .and_then(|o| o.description.clone());
+    let channel_description = match (&declared_description, &category_name) {
+        (Some(description), _) => description.clone(),
+        (None, Some(name)) => format!("{} posts in {}", posts_name, name),
+        (None, None) => format!("{} posts", posts_name),
     };
 
     let mut xml = String::with_capacity(4096);

--- a/tenrankai/src/posts/types.rs
+++ b/tenrankai/src/posts/types.rs
@@ -55,11 +55,35 @@ pub struct PostSummary {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CategoryInfo {
-    /// Display label as written in frontmatter
+    /// Display label as written in frontmatter, or the declared `name`
+    /// from _categories.md when the category is defined there
     pub name: String,
     /// URL-safe identifier used for filtering
     pub slug: String,
     pub count: usize,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Posts in an archive category are hidden from the unfiltered index
+    /// and main feed, but still listed on their category pages
+    #[serde(default)]
+    pub archive: bool,
+}
+
+/// Per-category options declared in _categories.md at the posts root,
+/// keyed by category slug. Categories without an entry keep the defaults.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CategoryOptions {
+    /// Canonical display label (otherwise taken from post frontmatter)
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub archive: bool,
+    /// Chip ordering: lower weights sort first, undeclared weights last
+    #[serde(default)]
+    pub weight: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/tenrankai/src/sitemap.rs
+++ b/tenrankai/src/sitemap.rs
@@ -427,14 +427,11 @@ async fn collect_posts_urls(
         )));
     }
 
-    let total_pages = manager.get_total_pages(None, None).await;
-    for page in 0..total_pages {
-        for post in manager.get_posts_page(page, None, None).await {
-            urls.push(UrlEntry::with_lastmod(
-                format!("{base_url}{}", post.url),
-                post.date.to_rfc3339(),
-            ));
-        }
+    for post in manager.get_public_post_summaries().await {
+        urls.push(UrlEntry::with_lastmod(
+            format!("{base_url}{}", post.url),
+            post.date.to_rfc3339(),
+        ));
     }
 }
 

--- a/tests/posts_integration.rs
+++ b/tests/posts_integration.rs
@@ -50,6 +50,12 @@ async fn setup_test_server_with_posts() -> (TempDir, TestServer) {
 {% include "_header.html.liquid" %}
 
 <h1>{{ posts_name | capitalize }}</h1>
+{% if active_category_description %}<p class="category-description">{{ active_category_description }}</p>{% endif %}
+<nav class="category-bar">
+    {% for category in categories %}
+    <span class="chip{% if category.archive %} archive{% endif %}">{{ category.name }}={{ category.count }}</span>
+    {% endfor %}
+</nav>
 <div class="posts-list">
     {% for post in posts %}
         <article>
@@ -425,6 +431,120 @@ Rust content."#;
     // Unknown category feeds are 404
     let response = server.get("/blog/category/nonexistent/feed.xml").await;
     assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_category_options_and_archive() {
+    let (_temp_dir, server) = setup_test_server_with_posts().await;
+
+    let blog_dir = _temp_dir.path().join("posts").join("blog");
+    fs::write(
+        blog_dir.join("_categories.md"),
+        r#"+++
+[categories.legacy]
+name = "The Archive"
+description = "Older posts kept for reference"
+archive = true
+
+[categories.travel]
+weight = 1
+
+[categories.gear]
+weight = 2
++++
+"#,
+    )
+    .unwrap();
+
+    let old_news = r#"+++
+title = "Old News"
+summary = "An archived post"
+date = "2024-02-01"
+categories = ["Legacy"]
++++
+
+Old content."#;
+    fs::write(blog_dir.join("old-news.md"), old_news).unwrap();
+
+    let travel_memories = r#"+++
+title = "Travel Memories"
+summary = "Archived but still a travel post"
+date = "2024-02-02"
+categories = ["Travel", "Legacy"]
++++
+
+Travel content."#;
+    fs::write(blog_dir.join("travel-memories.md"), travel_memories).unwrap();
+
+    let new_trip = r#"+++
+title = "New Trip"
+summary = "A current travel post"
+date = "2024-02-03"
+categories = ["Travel"]
++++
+
+Trip content."#;
+    fs::write(blog_dir.join("new-trip.md"), new_trip).unwrap();
+
+    let gear_post = r#"+++
+title = "Gear Notes"
+summary = "A gear post"
+date = "2024-02-04"
+categories = ["Gear"]
++++
+
+Gear content."#;
+    fs::write(blog_dir.join("gear-notes.md"), gear_post).unwrap();
+
+    server.post("/api/posts/blog/refresh").await;
+
+    // Archived posts are hidden from the unfiltered index
+    let html = server.get("/blog").await.text();
+    assert!(html.contains("New Trip"));
+    assert!(!html.contains("Old News"));
+    assert!(!html.contains("Travel Memories"));
+
+    // Chips: declared weights order Travel before Gear, archive category
+    // last with its declared display name; counts include archived posts
+    let travel = html.find("Travel=2").expect("travel chip with count");
+    let gear = html.find("Gear=1").expect("gear chip with count");
+    let archive = html
+        .find(r#"<span class="chip archive">The Archive=2</span>"#)
+        .expect("archive chip with declared name");
+    assert!(travel < gear && gear < archive);
+
+    // ...and from the main feed
+    let xml = server.get("/blog/feed.xml").await.text();
+    assert!(xml.contains("<title>New Trip</title>"));
+    assert!(!xml.contains("Old News"));
+
+    // Category pages list everything in the category, archived or not
+    let html = server.get("/blog/category/travel").await.text();
+    assert!(html.contains("New Trip"));
+    assert!(html.contains("Travel Memories"));
+
+    // The archive category page is the archive view, with the declared
+    // name and description
+    let html = server.get("/blog/category/legacy").await.text();
+    assert!(html.contains("Old News"));
+    assert!(html.contains("Travel Memories"));
+    assert!(html.contains("Older posts kept for reference"));
+
+    // Archived posts stay reachable at their permalinks
+    let response = server.get("/blog/old-news").await;
+    assert_eq!(response.status_code(), StatusCode::OK);
+
+    // The archive category feed uses the declared name and description
+    let xml = server.get("/blog/category/legacy/feed.xml").await.text();
+    assert!(xml.contains("The Archive"));
+    assert!(xml.contains("<description>Older posts kept for reference</description>"));
+    assert!(xml.contains("<title>Old News</title>"));
+
+    // Archived permalinks and the archive category page stay in the sitemap
+    let xml = server.get("/sitemap.xml").await.text();
+    assert!(xml.contains("/blog/old-news"));
+    assert!(xml.contains("/blog/travel-memories"));
+    assert!(xml.contains("/blog/category/legacy"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Categories gain a declaration file — `_categories.md` at the posts source root, following the `_folder.md` precedent — where each category (keyed by slug) can declare options:

```toml
+++
[categories.archive]
name = "Archive"
description = "Older posts kept for reference"
archive = true

[categories.travel]
weight = 1
+++
```

- **`archive`** — posts carrying an archive category disappear from the unfiltered index and the main RSS feed, but still list on every category page they belong to (the archive category's page *is* the archive view), stay reachable at their permalinks, and remain in the sitemap. Archiving a post is just adding a label.
- **`name`** — canonical display label, replacing today's "whichever post's spelling gets scanned first" behavior. Used on chips, filter notes, and feed channel titles.
- **`description`** — rendered under the category page heading, and used as the category feed's `<description>` and the page's meta description.
- **`weight`** — chip ordering (lower first, undeclared last, alphabetical within ties).

Everything is opt-in: undeclared categories behave exactly as before. Archive chips render at the end of the category bar after a visual separator, styled dashed/dimmed.

Because the sitemap previously enumerated posts through the paged index (which now hides archived posts), it gets its own enumeration (`get_public_post_summaries`) so archived permalinks keep their sitemap entries.

## Testing

- New integration test covering archive filtering on index/feed, dual-category posts (archived post still lists under its other categories), name/description/weight merging, permalink reachability, and sitemap inclusion
- New Playwright test + fixture (`_categories.md`, archive-only post) covering both index pages, the main feed, the separated archive chip, the category description, and the archive feed
- Full suite: 244 unit + all integration tests, 17 posts e2e + 5 editor e2e, clippy/fmt/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)