### PR TITLE
Parametrize the posts preview footer link label

### DIFF
--- a/e2e/tests/posts.spec.ts
+++ b/e2e/tests/posts.spec.ts
@@ -252,6 +252,7 @@ test.describe('posts preview embed', () => {
 
     // The footer link is server-rendered and goes to the posts index
     await page.goto('/');
+    await expect(component.locator('.btn-explore')).toHaveText('View All Posts →');
     await component.locator('.btn-explore').click();
     await expect(page).toHaveURL(/\/blog$/);
   });

--- a/templates/partials/_posts_preview.html.liquid
+++ b/templates/partials/_posts_preview.html.liquid
@@ -8,6 +8,7 @@
     - category:   (optional) Category slug to filter by
     - variant:    (optional) "list" for a super-compact title + date list
                   instead of summary cards
+    - link_text:  (optional) Label for the footer link (default "View All Posts")
 {% endcomment %}
 <section class="posts-preview-component{% if variant %} variant-{{ variant }}{% endif %}"
          data-posts-name="{{ posts_name }}"
@@ -18,6 +19,6 @@
     {% if heading %}<h2 class="posts-preview-heading">{{ heading }}</h2>{% endif %}
     <div class="posts-preview-list"></div>
     <div class="preview-footer posts-preview-footer">
-        <a href="{{ posts_url }}" class="btn-explore">View All Posts →</a>
+        <a href="{{ posts_url }}" class="btn-explore">{% if link_text %}{{ link_text }}{% else %}View All Posts{% endif %} →</a>
     </div>
 </section>


### PR DESCRIPTION
Adds an optional `link_text` include parameter to `_posts_preview.html.liquid` (default "View All Posts") so embeds for non-blog posts systems can label the footer link appropriately, e.g. `link_text: "View All Projects"`. Covered by an e2e assertion on the default label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)