### PR TITLE
Fix post gallery links to use index identifiers

### DIFF
--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -874,6 +874,19 @@ impl PostsManager {
         (html_output, first_image)
     }
 
+    /// The gallery's URL identifier for a source file path. Galleries with
+    /// sequence or unique_id indexing address images by index id, not
+    /// filename; deep-linking by filename renders but breaks navigation
+    /// (and defeats unique_id's filename privacy). Falls back to the raw
+    /// path when the image isn't indexed (yet).
+    async fn gallery_url_identifier(gallery: &SharedGallery, image_path: &str) -> String {
+        let indexer = gallery.image_indexer.read().await;
+        indexer
+            .get_index(image_path)
+            .map(str::to_string)
+            .unwrap_or_else(|| image_path.to_string())
+    }
+
     /// Resolve a hero image reference: either a `gallery:name:path` reference
     /// (served at gallery size, linked to its gallery detail page) or a plain
     /// URL passed through unchanged
@@ -883,12 +896,10 @@ impl PostsManager {
             let galleries = self.galleries.as_ref()?;
             let gallery = galleries.get(gallery_name)?;
             let gallery_config = gallery.get_config();
-            let encoded_path = urlencoding::encode(image_path);
-            let image_url = format!(
-                "{}/_image/{}/gallery",
-                gallery_config.url_prefix, encoded_path
-            );
-            let detail_url = format!("{}/detail/{}", gallery_config.url_prefix, encoded_path);
+            let identifier = Self::gallery_url_identifier(gallery, image_path).await;
+            let encoded = urlencoding::encode(&identifier);
+            let image_url = format!("{}/_image/{}/gallery", gallery_config.url_prefix, encoded);
+            let detail_url = format!("{}/detail/{}", gallery_config.url_prefix, encoded);
             return Some((image_url, Some(detail_url)));
         }
 
@@ -929,13 +940,12 @@ impl PostsManager {
         let gallery = galleries.get(gallery_name)?;
         let gallery_config = gallery.get_config();
 
-        // Generate URLs
-        let encoded_path = urlencoding::encode(image_path);
-        let image_url = format!(
-            "{}/_image/{}/{}",
-            gallery_config.url_prefix, encoded_path, size
-        );
-        let detail_url = format!("{}/detail/{}", gallery_config.url_prefix, encoded_path);
+        // Generate URLs from the gallery's URL identifier (index id for
+        // sequence/unique_id galleries) so detail-page navigation works
+        let identifier = Self::gallery_url_identifier(gallery, image_path).await;
+        let encoded = urlencoding::encode(&identifier);
+        let image_url = format!("{}/_image/{}/{}", gallery_config.url_prefix, encoded, size);
+        let detail_url = format!("{}/detail/{}", gallery_config.url_prefix, encoded);
 
         // Generate HTML with proper link. The details option adds data
         // attributes that the frontend turns into a hover card with the
@@ -945,7 +955,7 @@ impl PostsManager {
             format!(
                 r#" data-gallery-details data-gallery="{}" data-image-path="{}""#,
                 escape(gallery_name),
-                escape(image_path)
+                escape(&identifier)
             )
         } else {
             String::new()

--- a/tests/posts_integration.rs
+++ b/tests/posts_integration.rs
@@ -555,6 +555,115 @@ Gear content."#;
 }
 
 #[tokio::test]
+async fn test_gallery_links_use_index_identifiers() {
+    // A gallery with sequence indexing addresses images by index id, not
+    // filename; post-generated links must use the id or detail-page
+    // navigation breaks
+    let temp_dir = TempDir::new().unwrap();
+    let templates_dir = temp_dir.path().join("templates");
+    let modules_dir = templates_dir.join("modules");
+    let partials_dir = templates_dir.join("partials");
+    let gallery_dir = temp_dir.path().join("gallery");
+    let blog_dir = temp_dir.path().join("blog");
+    for dir in [&modules_dir, &partials_dir, &gallery_dir, &blog_dir] {
+        fs::create_dir_all(dir).unwrap();
+    }
+
+    fs::write(partials_dir.join("_header.html.liquid"), "<html><body>").unwrap();
+    fs::write(partials_dir.join("_footer.html.liquid"), "</body></html>").unwrap();
+    fs::write(
+        modules_dir.join("posts_index.html.liquid"),
+        r#"{% include "_header.html.liquid" %}{% include "_footer.html.liquid" %}"#,
+    )
+    .unwrap();
+    fs::write(
+        modules_dir.join("post_detail.html.liquid"),
+        r#"{% include "_header.html.liquid" %}
+{% if post.hero_image_link %}<a class="post-hero-link" href="{{ post.hero_image_link }}"></a>{% endif %}
+<div class="content">{{ post.html_content }}</div>
+{% include "_footer.html.liquid" %}"#,
+    )
+    .unwrap();
+
+    // Minimal valid 1x1 PNG
+    const PNG: [u8; 69] = [
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 2,
+        0, 0, 0, 144, 119, 83, 222, 0, 0, 0, 12, 73, 68, 65, 84, 120, 156, 99, 248, 207, 192, 0, 0,
+        3, 1, 1, 0, 201, 254, 146, 239, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+    fs::write(gallery_dir.join("only-image.png"), PNG).unwrap();
+
+    fs::write(
+        blog_dir.join("seq-post.md"),
+        r#"+++
+title = "Seq Post"
+summary = "Post referencing a sequence-indexed gallery"
+date = "2024-05-01"
+hero_image = "gallery:seq:only-image.png"
++++
+
+![gallery:seq:only-image.png](medium,details)
+"#,
+    )
+    .unwrap();
+
+    let config = SiteConfig {
+        name: "TestServer".to_string(),
+        base_url: Some("http://localhost:3000".to_string()),
+        cookie_secret: "test-cookie-secret".to_string(),
+        templates: TemplateConfig {
+            directories: vec![templates_dir.to_string_lossy().to_string()],
+        },
+        static_files: StaticConfig {
+            directories: vec![temp_dir.path().to_string_lossy().to_string()],
+            use_redirects: false,
+        },
+        galleries: Some(vec![tenrankai::GallerySystemConfig {
+            name: "seq".to_string(),
+            source_directory: gallery_dir.to_string_lossy().to_string(),
+            cache_directory: temp_dir.path().join("cache").to_string_lossy().to_string(),
+            gallery_template: "gallery.html.liquid".to_string(),
+            image_detail_template: "image_detail.html.liquid".to_string(),
+            image_indexing: tenrankai::ImageIndexingMode::Sequence,
+            ..Default::default()
+        }]),
+        posts: Some(vec![PostsSystemConfig {
+            name: "blog".to_string(),
+            source_directory: blog_dir.to_string_lossy().to_string(),
+            url_prefix: "/blog".to_string(),
+            index_template: "modules/posts_index.html.liquid".to_string(),
+            post_template: "modules/post_detail.html.liquid".to_string(),
+            posts_per_page: 10,
+            refresh_interval_minutes: None,
+            permissions: Default::default(),
+        }]),
+        user_database: None,
+        email: None,
+        config_storage: None,
+        site_admins: Vec::new(),
+        hosted_mode: false,
+        site_title: None,
+        copyright_holder: None,
+    };
+    let app = create_app(config, None).await;
+    let server = TestServer::new(app.into_make_service());
+
+    // Populate the gallery index, then re-render the post against it
+    server.get("/api/gallery/seq/data").await;
+    server.post("/api/posts/blog/refresh").await;
+
+    let html = server.get("/blog/seq-post").await.text();
+
+    // Sequence galleries address the only image as "1": links, image URLs,
+    // and the hover-card path all use the identifier, not the filename
+    assert!(html.contains(r#"href="/gallery/detail/1""#), "{html}");
+    assert!(html.contains("/gallery/_image/1/medium"));
+    assert!(html.contains(r#"data-image-path="1""#));
+    assert!(html.contains(r#"class="post-hero-link" href="/gallery/detail/1""#));
+    assert!(!html.contains("detail/only-image.png"));
+}
+
+#[tokio::test]
 async fn test_gallery_embeds_details_and_hero_link() {
     let (_temp_dir, server) = setup_test_server_with_posts().await;
 


### PR DESCRIPTION
Posts deep-linked gallery images by source filename. For galleries with `sequence` or `unique_id` indexing (theatr.us main uses `unique_id`), the detail page renders but prev/next navigation breaks, and the filename leaks — defeating unique_id's privacy purpose.

Gallery references (`gallery:name:path`) now resolve the gallery's URL identifier via the image indexer for all generated URLs: hero detail links, embed detail links, `_image` URLs, and the hover-card `data-image-path`. Unindexed paths (filename-mode galleries, images not yet scanned, or references already written as identifiers e.g. by the editor picker) fall back to the raw value, preserving today's behavior.

Regression test: a sequence-indexed gallery with a real image asserts every generated URL uses the index id and the filename appears in none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)