### PR TITLE
Transient overlays: live supernova markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "seiza"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=53db453#53db453d02e9a4345dd4b647769299be00bf47bc"
+source = "git+https://github.com/theatrus/seiza?rev=3c98c9b#3c98c9b3b72fe0ee1084f48fd08341b0e8672422"
 dependencies = [
  "image",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = { git = "https://github.com/theatrus/seiza", rev = "53db453" }
+seiza = { git = "https://github.com/theatrus/seiza", rev = "3c98c9b" }
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -170,13 +170,21 @@ export function AstroOverlay({ solution }: { solution: AstroSolution }) {
           )}
           {objects.map((o) => {
             const isStar = o.kind === 'star';
+            const isTransient = o.kind === 'transient';
             const label = labelText(o);
             const a = Math.max(o.semi_major_px, fontSize);
             const b = Math.max(o.semi_minor_px, fontSize);
             const y = labelY(o);
             return (
               <g key={`${o.name}-${o.x}-${o.y}`}>
-                {isStar ? (
+                {isTransient ? (
+                  <path
+                    d={`M ${o.x} ${o.y - a} L ${o.x + a} ${o.y} L ${o.x} ${o.y + a} L ${o.x - a} ${o.y} Z`}
+                    fill="none"
+                    stroke="#ff7be0"
+                    strokeWidth={stroke * 1.5}
+                  />
+                ) : isStar ? (
                   <>
                     <line
                       x1={o.x - a}
@@ -213,7 +221,7 @@ export function AstroOverlay({ solution }: { solution: AstroSolution }) {
                   y={y}
                   textAnchor="middle"
                   fontSize={fontSize}
-                  fill={isStar ? '#ffd479' : '#aee8ff'}
+                  fill={isTransient ? '#ff7be0' : isStar ? '#ffd479' : '#aee8ff'}
                   stroke="rgba(0,0,0,0.8)"
                   strokeWidth={fontSize / 10}
                   paintOrder="stroke"

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -32,9 +32,51 @@ const DETECT_MAX_DIM: u32 = 2800;
 pub struct AstroContext {
     stars: TileCatalog,
     objects: Option<ObjectCatalog>,
+    /// Transients reload when the file changes (a cron refreshes it)
+    transients: Option<ReloadingCatalog>,
     /// Failed solve attempts this process, keyed by "gallery/path" —
     /// successes persist into the image's metadata sidecar instead
     failed: RwLock<HashMap<String, ()>>,
+}
+
+/// An object catalog that rereads its file when the mtime changes.
+struct ReloadingCatalog {
+    path: std::path::PathBuf,
+    state: RwLock<(std::time::SystemTime, Arc<ObjectCatalog>)>,
+}
+
+impl ReloadingCatalog {
+    fn open(path: &std::path::Path) -> Option<Self> {
+        let mtime = std::fs::metadata(path).ok()?.modified().ok()?;
+        let catalog = ObjectCatalog::open(path).ok()?;
+        Some(Self {
+            path: path.to_path_buf(),
+            state: RwLock::new((mtime, Arc::new(catalog))),
+        })
+    }
+
+    async fn current(&self) -> Arc<ObjectCatalog> {
+        let mtime = std::fs::metadata(&self.path)
+            .and_then(|m| m.modified())
+            .ok();
+        {
+            let state = self.state.read().await;
+            match mtime {
+                Some(mtime) if mtime != state.0 => {}
+                _ => return state.1.clone(),
+            }
+        }
+        let mut state = self.state.write().await;
+        if let (Some(mtime), Ok(catalog)) = (mtime, ObjectCatalog::open(&self.path)) {
+            info!(
+                "astro: reloaded {} transients from {}",
+                catalog.len(),
+                self.path.display()
+            );
+            *state = (mtime, Arc::new(catalog));
+        }
+        state.1.clone()
+    }
 }
 
 impl AstroContext {
@@ -76,9 +118,17 @@ impl AstroContext {
             },
             None => None,
         };
+        let transients = config.transient_data.as_deref().and_then(|path| {
+            let catalog = ReloadingCatalog::open(path);
+            if catalog.is_none() {
+                warn!("astro: failed to open transient data {}", path.display());
+            }
+            catalog
+        });
         Some(Arc::new(Self {
             stars,
             objects,
+            transients,
             failed: RwLock::new(HashMap::new()),
         }))
     }
@@ -189,7 +239,7 @@ pub async fn astro_handler(
         .ok()
         .flatten();
     if let Some(solution) = existing.as_ref().and_then(|m| m.astro.as_ref()) {
-        return solution_response(solution);
+        return solution_response(solution, &astro).await;
     }
 
     let cache_key = format!("{gallery_name}/{resolved_path}");
@@ -211,7 +261,7 @@ pub async fn astro_handler(
             {
                 warn!("astro: failed to persist solution for {resolved_path}: {e}");
             }
-            solution_response(&solution)
+            solution_response(&solution, &astro).await
         }
         None => {
             astro.failed.write().await.insert(cache_key, ());
@@ -222,8 +272,9 @@ pub async fn astro_handler(
     }
 }
 
-fn solution_response(
+async fn solution_response(
     solution: &crate::metadata_storage::AstroSolution,
+    astro: &Arc<AstroContext>,
 ) -> axum::response::Response {
     let wcs = Wcs {
         crval: (solution.crval[0], solution.crval[1]),
@@ -234,7 +285,7 @@ fn solution_response(
     let (center_ra, center_dec) = wcs.pixel_to_world(dims.0 as f64 / 2.0, dims.1 as f64 / 2.0);
     let footprint = wcs.footprint(dims.0, dims.1);
 
-    let objects: Vec<serde_json::Value> = solution
+    let mut objects: Vec<serde_json::Value> = solution
         .objects
         .iter()
         .map(|o| {
@@ -251,6 +302,24 @@ fn solution_response(
             })
         })
         .collect();
+
+    // Transients are projected live (never persisted): discoveries change
+    if let Some(transients) = &astro.transients {
+        let catalog = transients.current().await;
+        for p in catalog.objects_in_footprint(&wcs, dims) {
+            objects.push(serde_json::json!({
+                "name": p.object.name,
+                "common_name": p.object.common_name,
+                "kind": "transient",
+                "mag": p.object.mag,
+                "x": p.x,
+                "y": p.y,
+                "semi_major_px": p.semi_major_px,
+                "semi_minor_px": p.semi_minor_px,
+                "angle_deg": p.angle_deg,
+            }));
+        }
+    }
 
     let mut response = axum::Json(serde_json::json!({
         "solved": true,

--- a/tenrankai/src/config/types.rs
+++ b/tenrankai/src/config/types.rs
@@ -34,6 +34,10 @@ pub struct AstroConfig {
     /// Object catalog built by `seiza build-data objects` (SEIZAOB1)
     #[serde(default)]
     pub object_data: Option<std::path::PathBuf>,
+    /// Transient catalog built by `seiza build-data transients`; reloaded
+    /// automatically when the file changes, so a cron can refresh it
+    #[serde(default)]
+    pub transient_data: Option<std::path::PathBuf>,
 }
 
 /// Configuration for the cache generation queue.


### PR DESCRIPTION
Adds `transient_data` to `[astro]`: a seiza transient catalog built from the Rochester Astronomy active supernova list (7,910 events; no registration required, unlike TNS dumps). Transients are projected through the solved WCS **at request time** — never persisted into sidecars, since discoveries and magnitudes change — and the catalog hot-reloads when the file's mtime changes, so a nightly cron can refresh it without a restart. The overlay draws them as magenta diamonds labeled with type, discovery date, and host.

Validation: solving the SN 2026sqf discovery frame places the transient diamond exactly inside the hand-drawn marker on the labeled image, alongside NGC 3310's ellipse and an HD star label.

Also bumps seiza (transient catalog builder + seiza-fits: dependency-free FITS reading with native u16 path, histogram stats, and N.I.N.A.-compatible MTF autostretch — raw subs now solve directly from their FITS headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)