### PR TITLE
Use seiza from crates.io (0.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,10 +4274,12 @@ dependencies = [
 [[package]]
 name = "seiza"
 version = "0.1.0"
-source = "git+https://github.com/theatrus/seiza?rev=3c98c9b#3c98c9b3b72fe0ee1084f48fd08341b0e8672422"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37108a7523280d3d72eabb55a8e93db02e2f8e36d5fc57f3779e2ace061e5327"
 dependencies = [
  "image",
  "memmap2",
+ "rayon",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = { git = "https://github.com/theatrus/seiza", rev = "3c98c9b" }
+seiza = "0.1"
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 


### PR DESCRIPTION
seiza, seiza-fits, and seiza-cli 0.1.0 are now published on crates.io, so the git rev pin is no longer needed. The published version additionally includes blind plate solving and OSC debayering (not yet used here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)