### PR TITLE
Astro overlay on gallery images embedded in posts

### DIFF
--- a/e2e/tests/astro-overlay.spec.ts
+++ b/e2e/tests/astro-overlay.spec.ts
@@ -177,3 +177,31 @@ test.describe('astro overlay', () => {
     await shot(page, 'astro-overlay-mobile-zoom');
   });
 });
+
+test.describe('astro overlay in post embeds', () => {
+  test('embedded gallery image offers the Objects toggle and renders labels', async ({
+    page,
+  }) => {
+    await page.route('**/api/gallery/*/astro/**', (route) =>
+      route.fulfill({ json: SOLUTION }),
+    );
+    await page.goto('/blog/camera-bag');
+
+    const embed = page.locator('a.gallery-image-link[data-gallery]').first();
+    await expect(embed).toBeVisible();
+
+    const toggle = embed.getByRole('button', { name: /Objects \(/ });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const svg = embed.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg).toBeVisible();
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toBeVisible();
+    await shot(page, 'astro-overlay-post-embed');
+
+    // The toggle must not navigate to the detail page
+    await expect(page).toHaveURL(/\/blog\/camera-bag/);
+    await embed.getByRole('button', { name: 'Objects ✕' }).click();
+    await expect(svg).toHaveCount(0);
+  });
+});

--- a/frontend/react/app.ts
+++ b/frontend/react/app.ts
@@ -15,6 +15,7 @@ import './pages/login-success.ts';
 import './pages/passkey-enrollment.ts';
 import './pages/passkeys.ts';
 import './pages/gallery-image-hover.tsx';
+import './pages/post-astro-overlay.tsx';
 import './pages/post-detail.tsx';
 import './pages/posts-index.tsx';
 import './pages/posts-preview.tsx';

--- a/frontend/react/pages/post-astro-overlay.tsx
+++ b/frontend/react/pages/post-astro-overlay.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+  AstroOverlay,
+  AstroSolution,
+  distantTransients,
+  useAstroSolution,
+} from '../components/ImageDetail/AstroOverlay.tsx';
+
+/**
+ * Astro object labels for gallery images embedded in posts: every embed
+ * carries data-gallery/data-image-path; when the image has a plate
+ * solution, a small toggle appears over the embed and the standard
+ * overlay SVG renders on top of the image.
+ */
+
+const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, path }) => {
+  const solution = useAstroSolution(gallery, path);
+  const [visible, setVisible] = useState(false);
+
+  if (!solution) return null;
+  const shown = (solution.objects || []).length - (visible ? 0 : distantTransients(solution).length);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="post-astro-toggle"
+        onClick={(e) => {
+          // The embed is a link to the detail page; the toggle must not
+          // follow it
+          e.preventDefault();
+          e.stopPropagation();
+          setVisible(!visible);
+        }}
+        onTouchEnd={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setVisible(!visible);
+        }}
+        style={{
+          position: 'absolute',
+          right: '0.4rem',
+          bottom: '0.4rem',
+          zIndex: 3,
+          pointerEvents: 'auto',
+          touchAction: 'manipulation',
+          padding: '0.1rem 0.6rem',
+          borderRadius: '999px',
+          border: '1px solid rgba(255,255,255,0.4)',
+          background: visible ? 'rgba(80,180,255,0.4)' : 'rgba(0,0,0,0.55)',
+          color: '#fff',
+          fontSize: '0.72rem',
+          cursor: 'pointer',
+        }}
+        title="Toggle astronomical object labels"
+      >
+        {visible ? 'Objects ✕' : `Objects (${shown})`}
+      </button>
+      {visible && (
+        <span
+          style={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+            display: 'block',
+          }}
+        >
+          <AstroOverlay solution={solution as AstroSolution} visible allTransients={false} />
+        </span>
+      )}
+    </>
+  );
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  document
+    .querySelectorAll<HTMLAnchorElement>('a.gallery-image-link[data-gallery]')
+    .forEach((anchor) => {
+      const gallery = anchor.dataset.gallery;
+      const path = anchor.dataset.imagePath;
+      if (!gallery || !path) return;
+
+      anchor.style.position = 'relative';
+      anchor.style.display = 'inline-block';
+      const mount = document.createElement('span');
+      mount.style.display = 'contents';
+      anchor.appendChild(mount);
+      createRoot(mount).render(<EmbedOverlay gallery={gallery} path={path} />);
+    });
+});

--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -962,17 +962,11 @@ impl PostsManager {
         // attributes that the frontend turns into a hover card with the
         // image's description and technical details.
         let escape = crate::sitemap::xml_escape;
-        let details_attrs = if details {
-            format!(
-                r#" data-gallery-details data-gallery="{}" data-image-path="{}""#,
-                escape(gallery_name),
-                escape(&identifier)
-            )
-        } else {
-            String::new()
-        };
+        let details_attrs = if details { " data-gallery-details" } else { "" };
+        // data-gallery/data-image-path always: the astro overlay hydrator
+        // uses them to offer object labels on solved astro embeds
         let html = format!(
-            r#"<a href="{}" class="gallery-image-link{}"{}>
+            r#"<a href="{}" class="gallery-image-link{}" data-gallery="{}" data-image-path="{}"{}>
                 <img src="{}" alt="{}" loading="lazy" class="gallery-image gallery-image-{}" />
             </a>"#,
             detail_url,
@@ -981,6 +975,8 @@ impl PostsManager {
             } else {
                 ""
             },
+            escape(gallery_name),
+            escape(&identifier),
             details_attrs,
             image_url,
             escape(image_path.split('/').next_back().unwrap_or(image_path)),

--- a/tenrankai/src/posts/tests.rs
+++ b/tenrankai/src/posts/tests.rs
@@ -874,7 +874,7 @@ Regular markdown image (not a gallery reference):
 
         // Check that gallery references were converted to HTML
         assert!(post.html_content.contains(
-            r#"<a href="/gallery/detail/vacation/beach.jpg" class="gallery-image-link">"#
+            r#"<a href="/gallery/detail/vacation/beach.jpg" class="gallery-image-link" data-gallery="main" data-image-path="vacation/beach.jpg">"#
         ));
         assert!(
             post.html_content
@@ -886,7 +886,7 @@ Regular markdown image (not a gallery reference):
         );
 
         assert!(post.html_content.contains(
-            r#"<a href="/gallery/detail/vacation/sunset.jpg" class="gallery-image-link">"#
+            r#"<a href="/gallery/detail/vacation/sunset.jpg" class="gallery-image-link" data-gallery="main" data-image-path="vacation/sunset.jpg">"#
         ));
         assert!(
             post.html_content
@@ -897,7 +897,7 @@ Regular markdown image (not a gallery reference):
                 .contains(r#"class="gallery-image gallery-image-gallery""#)
         );
 
-        assert!(post.html_content.contains(r#"<a href="/my-portfolio/detail/projects/app-screenshot.png" class="gallery-image-link">"#));
+        assert!(post.html_content.contains(r#"<a href="/my-portfolio/detail/projects/app-screenshot.png" class="gallery-image-link" data-gallery="portfolio" data-image-path="projects/app-screenshot.png">"#));
         assert!(
             post.html_content
                 .contains(r#"<img src="/my-portfolio/_image/projects/app-screenshot.png/medium""#)


### PR DESCRIPTION
Gallery images embedded in posts now offer astro object labels inline. Every embed carries `data-gallery`/`data-image-path` (previously only `details` embeds did); a new hydrator queries the astro API and, when the image is solved, mounts a compact "Objects (N)" toggle over the embed. Toggling renders the standard overlay SVG (galaxies, stars, transients, comets/asteroids) directly over the embedded image, with click/touch handling that never follows the embed's detail-page link.

Playwright coverage on desktop and mobile: toggle appears on a mocked-solution embed, labels render, toggling off clears, and the post URL never changes. Full suite: 45 passed. Rust posts tests updated for the new embed attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)