### PR TITLE
Astro overlay on explicit post hero images

### DIFF
--- a/frontend/react/pages/post-astro-overlay.tsx
+++ b/frontend/react/pages/post-astro-overlay.tsx
@@ -75,7 +75,9 @@ const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, pa
 
 document.addEventListener('DOMContentLoaded', () => {
   document
-    .querySelectorAll<HTMLAnchorElement>('a.gallery-image-link[data-gallery]')
+    .querySelectorAll<HTMLAnchorElement>(
+      'a.gallery-image-link[data-gallery], a.post-hero-link[data-gallery]',
+    )
     .forEach((anchor) => {
       const gallery = anchor.dataset.gallery;
       const path = anchor.dataset.imagePath;

--- a/templates/modules/post_detail.html.liquid
+++ b/templates/modules/post_detail.html.liquid
@@ -31,7 +31,7 @@
     {% if post.hero_image and post.hero_image_explicit %}
     <figure class="post-hero">
         {% if post.hero_image_link %}
-        <a href="{{ post.hero_image_link }}" class="post-hero-link" title="View in gallery">
+        <a href="{{ post.hero_image_link }}" class="post-hero-link" title="View in gallery"{% if post.hero_image_gallery %} data-gallery="{{ post.hero_image_gallery }}" data-image-path="{{ post.hero_image_path }}"{% endif %}>
             <img src="{{ post.hero_image }}" alt="">
         </a>
         {% else %}

--- a/tenrankai/src/posts/core.rs
+++ b/tenrankai/src/posts/core.rs
@@ -292,12 +292,16 @@ impl PostsManager {
         let (html_content, first_image) = self.process_markdown_with_gallery_refs(parser).await;
 
         let hero_image_explicit = metadata.hero_image.is_some();
-        let (hero_image, hero_image_link) = match &metadata.hero_image {
+        let (hero_image, hero_image_link, hero_gallery_ref) = match &metadata.hero_image {
             Some(reference) => match self.resolve_image_reference(reference).await {
-                Some((url, link)) => (Some(url), link),
-                None => (None, None),
+                Some((url, link, gallery_ref)) => (Some(url), link, gallery_ref),
+                None => (None, None, None),
             },
-            None => (first_image, None),
+            None => (first_image, None, None),
+        };
+        let (hero_image_gallery, hero_image_path) = match hero_gallery_ref {
+            Some((gallery, path)) => (Some(gallery), Some(path)),
+            None => (None, None),
         };
 
         let reading_time_minutes = (markdown_content.split_whitespace().count() / 220).max(1);
@@ -314,6 +318,8 @@ impl PostsManager {
             hero_image,
             hero_image_link,
             hero_image_explicit,
+            hero_image_gallery,
+            hero_image_path,
             reading_time_minutes,
             last_modified,
         })
@@ -901,7 +907,10 @@ impl PostsManager {
     /// Resolve a hero image reference: either a `gallery:name:path` reference
     /// (served at gallery size, linked to its gallery detail page) or a plain
     /// URL passed through unchanged
-    async fn resolve_image_reference(&self, reference: &str) -> Option<(String, Option<String>)> {
+    async fn resolve_image_reference(
+        &self,
+        reference: &str,
+    ) -> Option<(String, Option<String>, Option<(String, String)>)> {
         if let Some(rest) = reference.strip_prefix("gallery:") {
             let (gallery_name, image_path) = rest.split_once(':')?;
             let galleries = self.galleries.as_ref()?;
@@ -911,10 +920,14 @@ impl PostsManager {
             let encoded = Self::encode_path(&identifier);
             let image_url = format!("{}/_image/{}/gallery", gallery_config.url_prefix, encoded);
             let detail_url = format!("{}/detail/{}", gallery_config.url_prefix, encoded);
-            return Some((image_url, Some(detail_url)));
+            return Some((
+                image_url,
+                Some(detail_url),
+                Some((gallery_name.to_string(), identifier)),
+            ));
         }
 
-        Some((reference.to_string(), None))
+        Some((reference.to_string(), None, None))
     }
 
     async fn process_gallery_reference(

--- a/tenrankai/src/posts/types.rs
+++ b/tenrankai/src/posts/types.rs
@@ -25,6 +25,12 @@ pub struct Post {
     /// so the detail page should render it above the post body
     #[serde(default)]
     pub hero_image_explicit: bool,
+    /// Gallery name + identifier when the hero is a gallery image, for
+    /// the astro overlay hydrator
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hero_image_gallery: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hero_image_path: Option<String>,
     #[serde(default)]
     pub reading_time_minutes: usize,
     #[serde(skip)]


### PR DESCRIPTION
Follow-up to #272: explicit gallery-backed hero images now carry `data-gallery`/`data-image-path` through the post template, and the overlay hydrator targets `.post-hero-link[data-gallery]` alongside inline embeds — a solved hero gets the same compact Objects toggle and label overlay. 476 Rust tests + 32 astro/posts Playwright specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)