### PR TITLE
Oriented comet tails and asteroid trails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744f31c79267b4a8b7cdf9a53ed26c7b086127aa54b0f61ba547eec3a639a5c0"
+checksum = "04eaad50f14c1ce9e78e7490406f74cc3b2b7284713daf795f90eed05366aaff"
 dependencies = [
  "image",
  "memmap2",
@@ -4917,7 +4917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = "0.2"
+seiza = "0.2.2"
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -176,14 +176,20 @@ export function AstroOverlay({ solution, visible, allTransients }: AstroOverlayP
             return (
               <g key={`${o.name}-${o.x}-${o.y}`}>
                 {isComet || isAsteroid ? (
-                  // Moving bodies: a diamond plus a short trailing dash,
-                  // in comet green or asteroid orange
-                  <path
-                    d={`M ${o.x} ${o.y - a} L ${o.x + a} ${o.y} L ${o.x} ${o.y + a} L ${o.x - a} ${o.y} Z M ${o.x + a * 1.3} ${o.y + a * 1.3} L ${o.x + a * 2.1} ${o.y + a * 2.1}`}
-                    fill="none"
-                    stroke={movingColor}
-                    strokeWidth={stroke * 1.5}
-                  />
+                  // Moving bodies: a diamond plus a directional dash — the
+                  // comet's anti-solar tail or the asteroid's motion trail
+                  (() => {
+                    const rad = ((o.angle_deg || 45) * Math.PI) / 180;
+                    const [dx, dy] = [Math.cos(rad), Math.sin(rad)];
+                    return (
+                      <path
+                        d={`M ${o.x} ${o.y - a} L ${o.x + a} ${o.y} L ${o.x} ${o.y + a} L ${o.x - a} ${o.y} Z M ${o.x + a * 1.3 * dx} ${o.y + a * 1.3 * dy} L ${o.x + a * 3.2 * dx} ${o.y + a * 3.2 * dy}`}
+                        fill="none"
+                        stroke={movingColor}
+                        strokeWidth={stroke * 1.5}
+                      />
+                    );
+                  })()
                 ) : isTransient ? (
                   <path
                     d={`M ${o.x} ${o.y - a} L ${o.x + a} ${o.y} L ${o.x} ${o.y + a} L ${o.x - a} ${o.y} Z`}

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -468,6 +468,15 @@ async fn solution_response(
                 seiza::minor_bodies::MinorBodyKind::Comet => "comet",
                 seiza::minor_bodies::MinorBodyKind::Asteroid => "asteroid",
             };
+            // Sky position angle (comet tail / asteroid trail) becomes a
+            // pixel-space angle by projecting a small step along it
+            let angle_deg = m.direction_pa_deg.and_then(|pa| {
+                let step = 0.05;
+                let ra2 = m.ra + step * pa.to_radians().sin() / m.dec.to_radians().cos().max(0.05);
+                let dec2 = (m.dec + step * pa.to_radians().cos()).clamp(-89.9, 89.9);
+                let (x2, y2) = wcs.world_to_pixel(ra2, dec2)?;
+                Some((y2 - m.y).atan2(x2 - m.x).to_degrees())
+            });
             objects.push(serde_json::json!({
                 "name": m.body.name,
                 "common_name": format!("V~{:.1}, {:.2} AU", m.mag, m.delta_au),
@@ -477,7 +486,7 @@ async fn solution_response(
                 "y": m.y,
                 "semi_major_px": 0.0,
                 "semi_minor_px": 0.0,
-                "angle_deg": 0.0,
+                "angle_deg": angle_deg.unwrap_or(0.0),
                 "near_capture": true,
             }));
         }


### PR DESCRIPTION
seiza 0.2.2 computes each minor body's characteristic sky direction — anti-solar position angle for comet tails, apparent-motion bearing for asteroid trails. The astro response projects it through the solved WCS into a pixel-space angle, and the overlay's marker dash now points along it instead of a fixed 45°.

On the real C/2025 A6 (Lemmon) frame the dash tracks the actual visible tail:

![comet tail oriented](https://downloads.seiza.fyi/pr-assets/tenrankai-tails/comet-tail.png)

Also bumps seiza to 0.2.2 (which additionally carries the ASTAP-compatible N.I.N.A. mode in the CLI). 476 Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)