### PR TITLE
Per-catalog toggles in objects mode + hero/embed overlay fixes

### DIFF
--- a/e2e/tests/astro-overlay.spec.ts
+++ b/e2e/tests/astro-overlay.spec.ts
@@ -205,3 +205,39 @@ test.describe('astro overlay in post embeds', () => {
     await expect(svg).toHaveCount(0);
   });
 });
+
+test.describe('per-catalog toggles', () => {
+  test('catalog menu hides and restores groups, persisting the choice', async ({
+    page,
+    isMobile,
+  }) => {
+    await openSolvedDetail(page);
+    const tapOrClick = async (locator: ReturnType<typeof page.locator>) =>
+      isMobile ? locator.tap() : locator.click();
+
+    await tapOrClick(page.getByRole('button', { name: /Objects \(/ }));
+    const svg = page.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toBeVisible();
+
+    // Open the catalogs menu and hide the NGC/IC/Messier group
+    await tapOrClick(page.getByRole('button', { name: /Catalogs/ }));
+    const ngc = page.locator('.astro-catalog-item', { hasText: 'NGC / IC / Messier' });
+    await expect(ngc).toBeVisible();
+    await tapOrClick(ngc);
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toHaveCount(0);
+    // Other groups stay
+    await expect(svg.getByText(/WR 134/)).toBeVisible();
+    await shot(page, 'astro-catalog-toggles');
+
+    // The choice persists across a reload
+    await page.reload();
+    await tapOrClick(page.getByRole('button', { name: /Objects \(/ }));
+    await expect(svg.getByText(/WR 134/)).toBeVisible();
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toHaveCount(0);
+
+    // And restores
+    await tapOrClick(page.getByRole('button', { name: /Catalogs/ }));
+    await tapOrClick(page.locator('.astro-catalog-item', { hasText: 'NGC / IC / Messier' }));
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toBeVisible();
+  });
+});

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -79,6 +79,34 @@ function encompassesFrame(o: PlacedObject, width: number, height: number): boole
   });
 }
 
+/** Catalog group of an object, for the per-catalog display toggles. */
+export function catalogGroup(o: PlacedObject): string {
+  if (o.kind === 'transient') return 'transients';
+  if (o.kind === 'comet' || o.kind === 'asteroid') return 'solar-system';
+  const name = o.name;
+  if (name.startsWith('PGC')) return 'pgc';
+  if (name.startsWith('UGC')) return 'ugc';
+  if (name.startsWith('LDN') || /^B\d/.test(name)) return 'dark-nebulae';
+  if (name.startsWith('SNR')) return 'snr';
+  if (name.startsWith('WR ')) return 'wr';
+  if (o.kind === 'star' || o.kind === 'double-star') return 'stars';
+  if (name.startsWith('Sh2-') || name.startsWith('vdB')) return 'sharpless-vdb';
+  return 'ngc-ic-messier';
+}
+
+/** Display names for catalog groups, in menu order. */
+export const CATALOG_GROUPS: [string, string][] = [
+  ['ngc-ic-messier', 'NGC / IC / Messier'],
+  ['sharpless-vdb', 'Sharpless / vdB'],
+  ['dark-nebulae', 'Dark nebulae (B / LDN)'],
+  ['snr', 'Supernova remnants'],
+  ['wr', 'Wolf-Rayet stars'],
+  ['stars', 'Stars (HD / named)'],
+  ['ugc', 'UGC galaxies'],
+  ['pgc', 'PGC galaxies'],
+  ['solar-system', 'Comets / asteroids'],
+];
+
 /** Transients not discovered near the capture date (hidden by default). */
 export function distantTransients(solution: AstroSolution): PlacedObject[] {
   return (solution.objects || []).filter(
@@ -90,17 +118,26 @@ interface AstroOverlayProps {
   solution: AstroSolution;
   visible: boolean;
   allTransients: boolean;
+  /** Catalog groups (see [`catalogGroup`]) currently hidden */
+  hiddenGroups?: string[];
 }
 
 /** The SVG marker layer. Toggle buttons live in [`AstroControls`]. */
-export function AstroOverlay({ solution, visible, allTransients }: AstroOverlayProps) {
+export function AstroOverlay({
+  solution,
+  visible,
+  allTransients,
+  hiddenGroups = [],
+}: AstroOverlayProps) {
 
   const width = solution.width;
   const height = solution.height;
   // Transients not discovered near the capture date are noise by default
   // (M31 accumulates hundreds of historical novae) but can be toggled on
-  const everything = solution.objects || [];
-  const distant = distantTransients(solution);
+  const everything = (solution.objects || []).filter(
+    (o) => !hiddenGroups.includes(catalogGroup(o)),
+  );
+  const distant = distantTransients(solution).filter((o) => everything.includes(o));
   const all = allTransients ? everything : everything.filter((o) => !distant.includes(o));
   const encompassing = all.filter((o) => encompassesFrame(o, width, height));
   const objects = all.filter((o) => !encompassing.includes(o));
@@ -264,6 +301,8 @@ interface AstroControlsProps {
   onVisibleChange: (visible: boolean) => void;
   allTransients: boolean;
   onAllTransientsChange: (all: boolean) => void;
+  hiddenGroups: string[];
+  onHiddenGroupsChange: (groups: string[]) => void;
 }
 
 /**
@@ -276,10 +315,28 @@ export function AstroControls({
   onVisibleChange,
   allTransients,
   onAllTransientsChange,
+  hiddenGroups,
+  onHiddenGroupsChange,
 }: AstroControlsProps) {
-  const total = (solution.objects || []).length;
-  const distant = distantTransients(solution);
-  const shown = allTransients ? total : total - distant.length;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const objects = solution.objects || [];
+  const groupCounts = new Map<string, number>();
+  for (const o of objects) {
+    const group = catalogGroup(o);
+    groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
+  }
+  const kept = objects.filter((o) => !hiddenGroups.includes(catalogGroup(o)));
+  const distant = distantTransients(solution).filter((o) => kept.includes(o));
+  const shown = allTransients ? kept.length : kept.length - distant.length;
+  const availableGroups = CATALOG_GROUPS.filter(([id]) => groupCounts.has(id));
+
+  const toggleGroup = (id: string) => {
+    onHiddenGroupsChange(
+      hiddenGroups.includes(id)
+        ? hiddenGroups.filter((g) => g !== id)
+        : [...hiddenGroups, id],
+    );
+  };
 
   return (
     <div className="control-buttons astro-controls">
@@ -300,6 +357,35 @@ export function AstroControls({
         >
           {allTransients ? 'Hide old transients' : `+${distant.length} old transients`}
         </button>
+      )}
+      {visible && availableGroups.length > 1 && (
+        <span style={{ position: 'relative', display: 'inline-block' }}>
+          <button
+            type="button"
+            className={`btn ${hiddenGroups.length > 0 ? 'btn-primary' : 'btn-secondary'}`}
+            aria-expanded={menuOpen}
+            onClick={() => setMenuOpen(!menuOpen)}
+            title="Choose which catalogs to label"
+          >
+            Catalogs {menuOpen ? '▴' : '▾'}
+          </button>
+          {menuOpen && (
+            <span className="astro-catalog-menu" role="menu">
+              {availableGroups.map(([id, label]) => (
+                <label key={id} className="astro-catalog-item">
+                  <input
+                    type="checkbox"
+                    checked={!hiddenGroups.includes(id)}
+                    onChange={() => toggleGroup(id)}
+                  />
+                  <span>
+                    {label} ({groupCounts.get(id)})
+                  </span>
+                </label>
+              ))}
+            </span>
+          )}
+        </span>
       )}
     </div>
   );

--- a/frontend/react/pages/image-detail.tsx
+++ b/frontend/react/pages/image-detail.tsx
@@ -120,6 +120,21 @@ export function ImageDetailPage({
   );
   const [astroVisible, setAstroVisible] = useState(false);
   const [astroAllTransients, setAstroAllTransients] = useState(false);
+  const [astroHiddenGroups, setAstroHiddenGroupsState] = useState<string[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('astro-hidden-catalogs') || '[]');
+    } catch {
+      return [];
+    }
+  });
+  const setAstroHiddenGroups = (groups: string[]) => {
+    setAstroHiddenGroupsState(groups);
+    try {
+      localStorage.setItem('astro-hidden-catalogs', JSON.stringify(groups));
+    } catch {
+      /* private mode */
+    }
+  };
 
   // Modal state for editing image info
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
@@ -279,6 +294,7 @@ export function ImageDetailPage({
                       solution={astroSolution}
                       visible={astroVisible}
                       allTransients={astroAllTransients}
+                      hiddenGroups={astroHiddenGroups}
                     />
                   ) : undefined
                 }
@@ -288,6 +304,7 @@ export function ImageDetailPage({
                       solution={astroSolution}
                       visible
                       allTransients={astroAllTransients}
+                      hiddenGroups={astroHiddenGroups}
                     />
                   ) : undefined
                 }
@@ -303,6 +320,8 @@ export function ImageDetailPage({
               onVisibleChange={setAstroVisible}
               allTransients={astroAllTransients}
               onAllTransientsChange={setAstroAllTransients}
+              hiddenGroups={astroHiddenGroups}
+              onHiddenGroupsChange={setAstroHiddenGroups}
             />
           )}
 

--- a/frontend/react/pages/post-astro-overlay.tsx
+++ b/frontend/react/pages/post-astro-overlay.tsx
@@ -85,6 +85,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
       anchor.style.position = 'relative';
       anchor.style.display = 'inline-block';
+      anchor.style.lineHeight = '0';
+      // Kill the inline-image baseline gap so the anchor box matches the
+      // image exactly (a few px of descender space otherwise shifts the
+      // overlay downward)
+      const img = anchor.querySelector('img');
+      if (img) img.style.display = 'block';
       const mount = document.createElement('span');
       mount.style.display = 'contents';
       anchor.appendChild(mount);

--- a/static/image-detail.css
+++ b/static/image-detail.css
@@ -432,6 +432,59 @@ body {
     }
 }
 
+/* Per-catalog dropdown: a pill-styled popover above the toggle */
+.astro-catalog-menu {
+    position: absolute;
+    bottom: calc(100% + 0.4rem);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 15rem;
+    padding: 0.5rem;
+    border-radius: 1rem;
+    border: 1px solid var(--border-color, rgba(128, 128, 128, 0.4));
+    background: var(--bg-primary, #fff);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, 0.25);
+    text-align: left;
+}
+
+.astro-catalog-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.astro-catalog-item:hover {
+    background: rgba(128, 160, 255, 0.12);
+}
+
+.astro-catalog-item input {
+    accent-color: #3b82f6;
+    width: 1rem;
+    height: 1rem;
+}
+
+@media (pointer: coarse) {
+    .astro-catalog-item {
+        min-height: 44px;
+        font-size: 0.95rem;
+    }
+
+    .astro-catalog-item input {
+        width: 1.3rem;
+        height: 1.3rem;
+    }
+}
+
 .nav-hint-container {
     margin-top: var(--spacing-sm);
 }

--- a/tenrankai/src/posts/handlers.rs
+++ b/tenrankai/src/posts/handlers.rs
@@ -326,6 +326,8 @@ pub async fn post_detail_handler(
             "hero_image": post.hero_image,
             "hero_image_link": post.hero_image_link,
             "hero_image_explicit": post.hero_image_explicit,
+            "hero_image_gallery": post.hero_image_gallery,
+            "hero_image_path": post.hero_image_path,
             "reading_time_minutes": post.reading_time_minutes,
         },
         "posts_name": posts_name,


### PR DESCRIPTION
**Per-catalog toggles.** A "Catalogs ▾" dropdown joins the overlay pill row: objects classify into catalog groups (NGC/IC/Messier, Sharpless/vdB, dark nebulae B/LDN, SNRs, Wolf-Rayet, HD/named stars, UGC, PGC, comets/asteroids) with per-group counts, each toggleable when it clutters a field. Choices persist in localStorage; the popover is pill-styled and touch-friendly (44px items on coarse pointers). The comet frame below has PGC (69 labels!) and UGC unticked — just the comet remains, tail dash tracking the real tail:

![catalog toggles decluttering](https://downloads.seiza.fyi/pr-assets/tenrankai-tails/catalog-toggles.png)

**Two fixes from production reports:**
- The post *hero* overlay never appeared: the post-detail handler builds its liquid context field-by-field and the new `hero_image_gallery`/`hero_image_path` fields were never passed through, so the template condition was always false.
- Post-embed overlays sat a few px low: the inline-image baseline gap made the anchor box taller than the image; the hydrator now sets the image `display: block`.

E2E: new catalog-toggle spec (hide → persists across reload → restore) runs on desktop and the Pixel 7 mobile project; full suite 47 passed. 476 Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)