### PR TITLE
Post overlay polish: alignment, hover-card legibility, catalog menu in embeds

### DIFF
--- a/e2e/tests/astro-overlay.spec.ts
+++ b/e2e/tests/astro-overlay.spec.ts
@@ -241,3 +241,87 @@ test.describe('per-catalog toggles', () => {
     await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toBeVisible();
   });
 });
+
+test.describe('post embed overlay geometry and menus', () => {
+  test('overlay aligns with the image and the hover card stays legible', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(isMobile, 'hover interactions are desktop-only');
+    await page.route('**/api/gallery/*/astro/**', (route) =>
+      route.fulfill({ json: SOLUTION }),
+    );
+    await page.goto('/blog/camera-bag');
+
+    const embed = page.locator('a.gallery-image-link[data-gallery]').first();
+    const img = embed.locator('img');
+    await embed.getByRole('button', { name: /Objects \(/ }).click();
+
+    // The SVG overlay must match the image box (the inline baseline gap
+    // used to shift it a few px down)
+    const svg = embed.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg).toBeVisible();
+    const imgBox = (await img.boundingBox())!;
+    const svgBox = (await svg.boundingBox())!;
+    expect(Math.abs(svgBox.y - imgBox.y)).toBeLessThanOrEqual(1.5);
+    expect(Math.abs(svgBox.height - imgBox.height)).toBeLessThanOrEqual(1.5);
+
+    // The details hover card (same anchor) must keep a readable
+    // line-height — the overlay wrapper's line-height: 0 must not leak
+    await embed.hover();
+    const card = page.locator('.gallery-hover-mount > div').first();
+    await expect(card).toBeVisible();
+    const lineHeight = await card.evaluate((el) => getComputedStyle(el).lineHeight);
+    expect(lineHeight).not.toBe('0px');
+    const rows = card.locator('dt');
+    if ((await rows.count()) >= 2) {
+      const first = (await rows.nth(0).boundingBox())!;
+      const second = (await rows.nth(1).boundingBox())!;
+      expect(second.y).toBeGreaterThanOrEqual(first.y + first.height - 1);
+    }
+    await shot(page, 'astro-embed-hover-legible');
+  });
+
+  test('embeds offer the catalog menu', async ({ page, isMobile }) => {
+    await page.route('**/api/gallery/*/astro/**', (route) =>
+      route.fulfill({ json: SOLUTION }),
+    );
+    await page.goto('/blog/camera-bag');
+    const embed = page.locator('a.gallery-image-link[data-gallery]').first();
+    const tapOrClick = async (l: ReturnType<typeof page.locator>) =>
+      isMobile ? l.tap() : l.click();
+
+    await tapOrClick(embed.getByRole('button', { name: /Objects \(/ }));
+    const svg = embed.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toBeVisible();
+
+    await tapOrClick(embed.getByRole('button', { name: /Catalogs/ }));
+    await tapOrClick(page.locator('.astro-catalog-item', { hasText: 'NGC / IC / Messier' }));
+    await expect(svg.getByText('NGC 224 · Andromeda Galaxy')).toHaveCount(0);
+    await expect(svg.getByText(/WR 134/)).toBeVisible();
+    // Still on the post page (controls never follow the embed link)
+    await expect(page).toHaveURL(/\/blog\/camera-bag/);
+  });
+
+  test('hero image pill sits inside the hero image box', async ({ page, isMobile }) => {
+    await page.route('**/api/gallery/*/astro/**', (route) =>
+      route.fulfill({ json: SOLUTION }),
+    );
+    await page.goto('/blog/first-trip');
+    const hero = page.locator('a.post-hero-link[data-gallery]');
+    await expect(hero).toBeVisible();
+
+    const img = hero.locator('img');
+    const pill = hero.getByRole('button', { name: /Objects \(/ });
+    await expect(pill).toBeVisible();
+    const imgBox = (await img.boundingBox())!;
+    const pillBox = (await pill.boundingBox())!;
+    expect(pillBox.x).toBeGreaterThanOrEqual(imgBox.x);
+    expect(pillBox.x + pillBox.width).toBeLessThanOrEqual(imgBox.x + imgBox.width + 1);
+    expect(pillBox.y + pillBox.height).toBeLessThanOrEqual(imgBox.y + imgBox.height + 1);
+
+    await (isMobile ? pill.tap() : pill.click());
+    await expect(hero.locator('svg[aria-label="Sky object overlay"]')).toBeVisible();
+    await shot(page, 'astro-hero-overlay');
+  });
+});

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -318,25 +318,13 @@ export function AstroControls({
   hiddenGroups,
   onHiddenGroupsChange,
 }: AstroControlsProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
   const objects = solution.objects || [];
-  const groupCounts = new Map<string, number>();
-  for (const o of objects) {
-    const group = catalogGroup(o);
-    groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
-  }
   const kept = objects.filter((o) => !hiddenGroups.includes(catalogGroup(o)));
   const distant = distantTransients(solution).filter((o) => kept.includes(o));
   const shown = allTransients ? kept.length : kept.length - distant.length;
-  const availableGroups = CATALOG_GROUPS.filter(([id]) => groupCounts.has(id));
-
-  const toggleGroup = (id: string) => {
-    onHiddenGroupsChange(
-      hiddenGroups.includes(id)
-        ? hiddenGroups.filter((g) => g !== id)
-        : [...hiddenGroups, id],
-    );
-  };
+  const availableGroups = CATALOG_GROUPS.filter(([id]) =>
+    objects.some((o) => catalogGroup(o) === id),
+  );
 
   return (
     <div className="control-buttons astro-controls">
@@ -359,34 +347,102 @@ export function AstroControls({
         </button>
       )}
       {visible && availableGroups.length > 1 && (
-        <span style={{ position: 'relative', display: 'inline-block' }}>
-          <button
-            type="button"
-            className={`btn ${hiddenGroups.length > 0 ? 'btn-primary' : 'btn-secondary'}`}
-            aria-expanded={menuOpen}
-            onClick={() => setMenuOpen(!menuOpen)}
-            title="Choose which catalogs to label"
-          >
-            Catalogs {menuOpen ? '▴' : '▾'}
-          </button>
-          {menuOpen && (
-            <span className="astro-catalog-menu" role="menu">
-              {availableGroups.map(([id, label]) => (
-                <label key={id} className="astro-catalog-item">
-                  <input
-                    type="checkbox"
-                    checked={!hiddenGroups.includes(id)}
-                    onChange={() => toggleGroup(id)}
-                  />
-                  <span>
-                    {label} ({groupCounts.get(id)})
-                  </span>
-                </label>
-              ))}
-            </span>
-          )}
-        </span>
+        <CatalogMenu
+          solution={solution}
+          hiddenGroups={hiddenGroups}
+          onHiddenGroupsChange={onHiddenGroupsChange}
+        />
       )}
     </div>
+  );
+}
+
+interface CatalogMenuProps {
+  solution: AstroSolution;
+  hiddenGroups: string[];
+  onHiddenGroupsChange: (groups: string[]) => void;
+  /** Small pill styling for tight spots (post embeds) */
+  compact?: boolean;
+}
+
+/** The per-catalog visibility dropdown, shared by the detail-page
+ * controls and post embeds. */
+export function CatalogMenu({
+  solution,
+  hiddenGroups,
+  onHiddenGroupsChange,
+  compact = false,
+}: CatalogMenuProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const groupCounts = new Map<string, number>();
+  for (const o of solution.objects || []) {
+    const group = catalogGroup(o);
+    groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
+  }
+  const availableGroups = CATALOG_GROUPS.filter(([id]) => groupCounts.has(id));
+  if (availableGroups.length < 2) return null;
+
+  const toggleGroup = (id: string) => {
+    onHiddenGroupsChange(
+      hiddenGroups.includes(id)
+        ? hiddenGroups.filter((g) => g !== id)
+        : [...hiddenGroups, id],
+    );
+  };
+  const stop = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return (
+    <span
+      style={{ position: 'relative', display: 'inline-block', pointerEvents: 'auto' }}
+      onClick={compact ? stop : undefined}
+      onTouchEnd={compact ? (e) => e.stopPropagation() : undefined}
+    >
+      <button
+        type="button"
+        className={compact ? 'post-astro-toggle-pill' : `btn ${hiddenGroups.length > 0 ? 'btn-primary' : 'btn-secondary'}`}
+        aria-expanded={menuOpen}
+        onClick={(e) => {
+          if (compact) stop(e);
+          setMenuOpen(!menuOpen);
+        }}
+        title="Choose which catalogs to label"
+        style={
+          compact
+            ? {
+                touchAction: 'manipulation',
+                padding: '0.1rem 0.6rem',
+                borderRadius: '999px',
+                border: '1px solid rgba(255,255,255,0.4)',
+                background:
+                  hiddenGroups.length > 0 ? 'rgba(80,180,255,0.4)' : 'rgba(0,0,0,0.55)',
+                color: '#fff',
+                fontSize: '0.72rem',
+                cursor: 'pointer',
+              }
+            : undefined
+        }
+      >
+        Catalogs {menuOpen ? '▴' : '▾'}
+      </button>
+      {menuOpen && (
+        <span className="astro-catalog-menu" role="menu">
+          {availableGroups.map(([id, label]) => (
+            <label key={id} className="astro-catalog-item">
+              <input
+                type="checkbox"
+                checked={!hiddenGroups.includes(id)}
+                onChange={() => toggleGroup(id)}
+              />
+              <span>
+                {label} ({groupCounts.get(id)})
+              </span>
+            </label>
+          ))}
+        </span>
+      )}
+    </span>
   );
 }

--- a/frontend/react/pages/post-astro-overlay.tsx
+++ b/frontend/react/pages/post-astro-overlay.tsx
@@ -3,60 +3,102 @@ import { createRoot } from 'react-dom/client';
 import {
   AstroOverlay,
   AstroSolution,
+  CatalogMenu,
   distantTransients,
+  catalogGroup,
   useAstroSolution,
 } from '../components/ImageDetail/AstroOverlay.tsx';
 
 /**
- * Astro object labels for gallery images embedded in posts: every embed
- * carries data-gallery/data-image-path; when the image has a plate
- * solution, a small toggle appears over the embed and the standard
- * overlay SVG renders on top of the image.
+ * Astro object labels for gallery images embedded in posts (inline
+ * embeds and gallery-backed hero images). The overlay mounts inside a
+ * wrapper around the image itself, so the pill and SVG align with the
+ * image box regardless of the surrounding anchor's layout — and the
+ * anchor (which also hosts the details hover card) keeps its normal
+ * line-height.
  */
+
+const HIDDEN_GROUPS_KEY = 'astro-hidden-catalogs';
+
+function loadHiddenGroups(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(HIDDEN_GROUPS_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
 
 const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, path }) => {
   const solution = useAstroSolution(gallery, path);
   const [visible, setVisible] = useState(false);
+  const [hiddenGroups, setHiddenGroupsState] = useState<string[]>(loadHiddenGroups);
+  const setHiddenGroups = (groups: string[]) => {
+    setHiddenGroupsState(groups);
+    try {
+      localStorage.setItem(HIDDEN_GROUPS_KEY, JSON.stringify(groups));
+    } catch {
+      /* private mode */
+    }
+  };
 
   if (!solution) return null;
-  const shown = (solution.objects || []).length - (visible ? 0 : distantTransients(solution).length);
+  const kept = (solution.objects || []).filter((o) => !hiddenGroups.includes(catalogGroup(o)));
+  const shown = kept.length - distantTransients(solution).filter((o) => kept.includes(o)).length;
+
+  const stop = (e: React.SyntheticEvent) => {
+    // The embed is a link to the detail page; controls must not follow it
+    e.preventDefault();
+    e.stopPropagation();
+  };
 
   return (
     <>
-      <button
-        type="button"
-        className="post-astro-toggle"
-        onClick={(e) => {
-          // The embed is a link to the detail page; the toggle must not
-          // follow it
-          e.preventDefault();
-          e.stopPropagation();
-          setVisible(!visible);
-        }}
-        onTouchEnd={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          setVisible(!visible);
-        }}
+      <span
         style={{
           position: 'absolute',
           right: '0.4rem',
           bottom: '0.4rem',
           zIndex: 3,
+          display: 'flex',
+          gap: '0.3rem',
+          lineHeight: 'normal',
           pointerEvents: 'auto',
-          touchAction: 'manipulation',
-          padding: '0.1rem 0.6rem',
-          borderRadius: '999px',
-          border: '1px solid rgba(255,255,255,0.4)',
-          background: visible ? 'rgba(80,180,255,0.4)' : 'rgba(0,0,0,0.55)',
-          color: '#fff',
-          fontSize: '0.72rem',
-          cursor: 'pointer',
         }}
-        title="Toggle astronomical object labels"
       >
-        {visible ? 'Objects ✕' : `Objects (${shown})`}
-      </button>
+        {visible && (
+          <CatalogMenu
+            solution={solution}
+            hiddenGroups={hiddenGroups}
+            onHiddenGroupsChange={setHiddenGroups}
+            compact
+          />
+        )}
+        <button
+          type="button"
+          className="post-astro-toggle"
+          onClick={(e) => {
+            stop(e);
+            setVisible(!visible);
+          }}
+          onTouchEnd={(e) => {
+            stop(e);
+            setVisible(!visible);
+          }}
+          style={{
+            touchAction: 'manipulation',
+            padding: '0.1rem 0.6rem',
+            borderRadius: '999px',
+            border: '1px solid rgba(255,255,255,0.4)',
+            background: visible ? 'rgba(80,180,255,0.4)' : 'rgba(0,0,0,0.55)',
+            color: '#fff',
+            fontSize: '0.72rem',
+            cursor: 'pointer',
+          }}
+          title="Toggle astronomical object labels"
+        >
+          {visible ? 'Objects ✕' : `Objects (${shown})`}
+        </button>
+      </span>
       {visible && (
         <span
           style={{
@@ -64,9 +106,15 @@ const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, pa
             inset: 0,
             pointerEvents: 'none',
             display: 'block',
+            lineHeight: 'normal',
           }}
         >
-          <AstroOverlay solution={solution as AstroSolution} visible allTransients={false} />
+          <AstroOverlay
+            solution={solution as AstroSolution}
+            visible
+            allTransients={false}
+            hiddenGroups={hiddenGroups}
+          />
         </span>
       )}
     </>
@@ -81,19 +129,29 @@ document.addEventListener('DOMContentLoaded', () => {
     .forEach((anchor) => {
       const gallery = anchor.dataset.gallery;
       const path = anchor.dataset.imagePath;
-      if (!gallery || !path) return;
-
-      anchor.style.position = 'relative';
-      anchor.style.display = 'inline-block';
-      anchor.style.lineHeight = '0';
-      // Kill the inline-image baseline gap so the anchor box matches the
-      // image exactly (a few px of descender space otherwise shifts the
-      // overlay downward)
       const img = anchor.querySelector('img');
-      if (img) img.style.display = 'block';
+      if (!gallery || !path || !img) return;
+
+      // Wrap only the image: the wrapper is the overlay's containing
+      // block, sized exactly to the image (line-height 0 kills the
+      // inline baseline gap without leaking into the hover card, which
+      // mounts on the anchor and needs its normal line-height)
+      const wrapper = document.createElement('span');
+      wrapper.style.position = 'relative';
+      wrapper.style.display = 'inline-block';
+      wrapper.style.lineHeight = '0';
+      // The image's own margins move to the wrapper so the wrapper box
+      // (and the overlay spanning it) coincides with the image exactly
+      const computed = getComputedStyle(img);
+      wrapper.style.margin = `${computed.marginTop} ${computed.marginRight} ${computed.marginBottom} ${computed.marginLeft}`;
+      img.parentNode?.insertBefore(wrapper, img);
+      wrapper.appendChild(img);
+      img.style.display = 'block';
+      img.style.margin = '0';
+
       const mount = document.createElement('span');
       mount.style.display = 'contents';
-      anchor.appendChild(mount);
+      wrapper.appendChild(mount);
       createRoot(mount).render(<EmbedOverlay gallery={gallery} path={path} />);
     });
 });


### PR DESCRIPTION
Fixes the three production reports:

- **Overlay offset**: the hydrator wraps only the image now, with the image's CSS margins transferred to the wrapper — the pill and SVG coincide with the image box exactly (the old anchor-level wrapper included baseline gap and image margins, shifting the SVG ~16px).
- **Squashed hover card**: `line-height: 0` was set on the anchor that also hosts the details hover card; it now lives on the image wrapper only, and the overlay spans declare `line-height: normal`.
- **Inconsistent pill placement hero vs embeds**: positioning against the image wrapper (not the anchor, which for heroes isn't shrink-wrapped) puts the pill at the image corner everywhere.

Plus: embeds get the **per-catalog dropdown** (shared `CatalogMenu` component, compact pill styling, same localStorage persistence as the detail page).

New Playwright geometry tests pin all of it: SVG box within 1.5px of the image box, hover-card `dt` rows strictly stacked with a non-zero line-height, catalog filtering inside embeds without navigation, and the hero pill contained by the hero image box — desktop + Pixel 7 mobile. Full suite: 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)