### PR TITLE
Bump seiza to 0.3.0 and support a prebuilt blind index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04eaad50f14c1ce9e78e7490406f74cc3b2b7284713daf795f90eed05366aaff"
+checksum = "a117df23b5465a540ca142f358c02512625cc7ef43699317b9814648a7cebf42"
 dependencies = [
  "image",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = "0.2.2"
+seiza = "0.3.0"
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 

--- a/README.md
+++ b/README.md
@@ -834,15 +834,26 @@ the [seiza](https://crates.io/crates/seiza) plate-solving library:
 - **Transient Markers**: Live markers (e.g. supernovae) from a separate
   transient catalog, scoped to each image's capture date; the catalog file is
   reloaded automatically when it changes, so a cron job can keep it fresh
+- **Blind Solving**: Images without RA/Dec metadata are solved from the star
+  field alone, using a prebuilt whole-sky pattern index
 
-Configure the data files (built with `seiza build-data`) in `config.toml`:
+Fetch the prebuilt catalogs (`seiza download-data prebuilt --output data`, or
+straight from [downloads.seiza.fyi](https://downloads.seiza.fyi/data/manifest.json))
+and point `config.toml` at them:
 
 ```toml
 [astro]
-star_data = "data/stars.seiza"          # Star tiles (SEIZAST1)
-object_data = "data/objects.seiza"      # Object catalog (SEIZAOB1, optional)
-transient_data = "data/transients.seiza" # Transient catalog (optional)
+star_data = "data/stars-deep-gaia17.bin"    # Star tiles (SEIZAST1)
+blind_index = "data/blind-gaia16.idx"       # Blind pattern index (SEIZABI1, optional)
+object_data = "data/objects.bin"            # Object catalog (SEIZAOB1, optional)
+transient_data = "data/transients.bin"      # Transient catalog (optional)
+minor_body_data = "data/minor-bodies.bin"   # Comets + asteroids (optional)
 ```
+
+`blind_index` is memory-mapped at first use and must come from the same
+catalog as `star_data`. Without it the index is built on demand from
+`star_data`, which covers only the bright tiers — small, fine-scale fields
+need the prebuilt index to blind-solve.
 
 When the object catalog changes, regenerate persisted overlays:
 

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -40,6 +40,8 @@ pub struct AstroContext {
     transients: Option<ReloadingCatalog>,
     /// Whole-sky pattern index for images with no coordinate hint —
     /// built once, lazily, on the first hint-less solve
+    /// Prebuilt index to memory-map; None builds the bright tiers on demand
+    blind_index_path: Option<std::path::PathBuf>,
     blind_index: tokio::sync::OnceCell<Option<Arc<seiza::blind::BlindIndex>>>,
     /// Comet/asteroid elements; positions depend on the capture time
     minor_bodies: Option<ReloadingMinorBodies>,
@@ -206,6 +208,7 @@ impl AstroContext {
             objects,
             objects_version,
             transients,
+            blind_index_path: config.blind_index.clone(),
             blind_index: tokio::sync::OnceCell::new(),
             minor_bodies,
             failed: RwLock::new(HashMap::new()),
@@ -517,9 +520,10 @@ async fn solution_response(
 /// Decode, detect, and solve one gallery image. Returns None when the image
 /// has no RA/Dec hint or no solution is found.
 /// Blind-solve parameters for the gallery path: the scale range spans the
-/// hinted ladder's coverage, and the magnitude limit keeps the pattern
-/// index a couple of hundred MB instead of multiple GB on deep catalogs.
-fn blind_params() -> seiza::blind::BlindParams {
+/// hinted ladder's coverage. Without a prebuilt index the magnitude limit
+/// keeps an on-demand build to a couple of hundred MB instead of multiple
+/// GB on deep catalogs — at the cost of the fine-scale tiers.
+fn blind_build_params() -> seiza::blind::BlindParams {
     seiza::blind::BlindParams {
         min_scale_arcsec_px: SCALE_LADDER[0] * (1.0 - SCALE_TOLERANCE),
         max_scale_arcsec_px: SCALE_LADDER[SCALE_LADDER.len() - 1] * (1.0 + SCALE_TOLERANCE),
@@ -528,27 +532,70 @@ fn blind_params() -> seiza::blind::BlindParams {
     }
 }
 
+/// Solving must use the depth and pattern extent the index was built with,
+/// whichever way it was obtained.
+fn blind_params(index: &seiza::blind::BlindIndex) -> seiza::blind::BlindParams {
+    seiza::blind::BlindParams {
+        index_mag_limit: index.index_mag_limit(),
+        max_pattern_deg: index.max_pattern_deg(),
+        ..blind_build_params()
+    }
+}
+
 impl AstroContext {
-    /// The blind pattern index, building it on first use (a few seconds).
+    /// The blind pattern index: memory-mapped from the configured file, or
+    /// built from the star catalog on first use (a few seconds).
     async fn blind_index(self: &Arc<Self>) -> Option<Arc<seiza::blind::BlindIndex>> {
         self.blind_index
             .get_or_init(|| async {
                 let astro = self.clone();
                 let built = tokio::task::spawn_blocking(move || {
                     let started = std::time::Instant::now();
-                    let index = seiza::blind::BlindIndex::build(&astro.stars, &blind_params());
+                    if let Some(path) = &astro.blind_index_path {
+                        match seiza::blind::BlindIndex::open(path) {
+                            Ok(index) => {
+                                let built_from = index.source_star_count();
+                                let stars = astro.stars.star_count();
+                                if built_from > 0
+                                    && built_from.max(stars) > 2 * built_from.min(stars)
+                                {
+                                    warn!(
+                                        "astro: blind index {} was built from {built_from} stars \
+                                         but star_data has {stars}; blind solves may fail",
+                                        path.display()
+                                    );
+                                }
+                                info!(
+                                    "astro: blind index mapped from {}: {} patterns (G<={:.1}) in {:.2}s",
+                                    path.display(),
+                                    index.pattern_count(),
+                                    index.index_mag_limit(),
+                                    started.elapsed().as_secs_f64()
+                                );
+                                return Some(Arc::new(index));
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "astro: failed to open blind index {}: {e}; building the \
+                                     bright tiers from star_data instead",
+                                    path.display()
+                                );
+                            }
+                        }
+                    }
+                    let index = seiza::blind::BlindIndex::build(&astro.stars, &blind_build_params());
                     info!(
                         "astro: blind index built: {} patterns in {:.1}s",
                         index.pattern_count(),
                         started.elapsed().as_secs_f64()
                     );
-                    Arc::new(index)
+                    Some(Arc::new(index))
                 })
                 .await;
                 match built {
-                    Ok(index) => Some(index),
+                    Ok(index) => index,
                     Err(e) => {
-                        warn!("astro: blind index build panicked: {e}");
+                        warn!("astro: blind index load panicked: {e}");
                         None
                     }
                 }
@@ -766,7 +813,7 @@ fn solve_bytes_blind(
 ) -> Option<crate::metadata_storage::AstroSolution> {
     let started = std::time::Instant::now();
     let (stars, dims) = detect_in_bytes(bytes, path)?;
-    match seiza::blind::solve_blind(&stars, &astro.stars, index, &blind_params(), dims) {
+    match seiza::blind::solve_blind(&stars, &astro.stars, index, &blind_params(index), dims) {
         Ok(Solution {
             wcs,
             matched_stars,

--- a/tenrankai/src/config/types.rs
+++ b/tenrankai/src/config/types.rs
@@ -31,6 +31,13 @@ pub struct Config {
 pub struct AstroConfig {
     /// Star tile file built by `seiza build-data` (SEIZAST1)
     pub star_data: std::path::PathBuf,
+    /// Prebuilt blind pattern index built by `seiza build-blind-index`
+    /// (SEIZABI1), memory-mapped at startup. Without it the index is built
+    /// from `star_data` on the first blind solve, which only covers the
+    /// bright tiers — small, fine-scale fields need the prebuilt index
+    /// (and it must come from the same catalog as `star_data`).
+    #[serde(default)]
+    pub blind_index: Option<std::path::PathBuf>,
     /// Object catalog built by `seiza build-data objects` (SEIZAOB1)
     #[serde(default)]
     pub object_data: Option<std::path::PathBuf>,


### PR DESCRIPTION
Bumps `seiza` 0.2.2 → 0.3.0 and wires up the new prebuilt blind-index support.

## Why

The blind index was built from `star_data` on the first blind solve, capped at G≤11.8 to keep that build to seconds and a few hundred MB. That cap means the fine-scale pattern tiers were never populated, so small, high-resolution fields could not blind-solve at all. seiza 0.3.0 adds a serialized, memory-mapped index format (`SEIZABI1`) so the deep index can be built once, offline, and hosted.

## Changes

- `[astro] blind_index` — optional path to an index from `seiza build-blind-index`, memory-mapped at first use (~0.06s for the hosted 29.6M-pattern G≤16 index vs. rebuilding every process).
- Solving now takes the magnitude limit and pattern extent **from the index** rather than assuming the build-time constants, so a deep index actually gets searched at its own depth.
- Warns when the index's source catalog is more than 2× away from the configured `star_data` (the header records the star count it was built from) — a mismatch otherwise just fails to solve with no explanation.
- Unset or unreadable `blind_index` falls back to the previous on-demand bright-tier build, so existing configs behave exactly as before.
- README: document the option and point at the prebuilt catalogs on downloads.seiza.fyi.

## Validation

seiza 0.3.0's own release validation ran the full astrobin gallery corpus (32 images): 28/32 blind, 30/31 hinted, every solution within 8″ of the cached production WCS. The deep index blind-solves the fine-scale fields that previously required a coordinate hint — the whirlpool q-mark image (0.163″/px) and NGC 3310 (0.33″/px) — in ~2s.

Here: `cargo clippy` clean, 280 tests pass.