### PR TITLE
Solve astro images at their known pixel scale, and reorder the scale ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,21 @@ catalog as `star_data`. Without it the index is built on demand from
 `star_data`, which covers only the bright tiers — small, fine-scale fields
 need the prebuilt index to blind-solve.
 
+Images are solved from their `.md` sidecar frontmatter: `ra` and `dec` give a
+hinted solve, and `pixel_scale` (arcseconds per pixel) makes it a single
+attempt instead of a walk up the scale ladder — worth setting, since each rung
+the solver walks past is a failed solve. Images with no coordinates are blind
+solved when the folder is marked `astro` or the frontmatter names a telescope.
+
+```toml
++++
+telescope = "Radian 61"
+ra = "21h 18m"
+dec = "+43° 57′"
+pixel_scale = 2.82   # 206.265 × pixel size (µm) ÷ focal length (mm)
++++
+```
+
 When the object catalog changes, regenerate persisted overlays:
 
 ```bash

--- a/tenrankai-metadata/src/types.rs
+++ b/tenrankai-metadata/src/types.rs
@@ -83,6 +83,12 @@ pub struct ImageUserMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dec: Option<String>,
 
+    /// Image scale in arcseconds per pixel, if known (206.265 × pixel size
+    /// in µm ÷ focal length in mm, adjusted for any resampling). Plate
+    /// solving tries this first instead of walking the scale ladder.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pixel_scale: Option<f64>,
+
     /// Additional details/notes
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_details: Option<String>,

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -20,12 +20,25 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{info, warn};
 
-/// Pixel-scale ladder tried in order; ±35 % tolerance makes the rungs
-/// overlap, covering roughly 0.23–7.5 arcsec/pixel.
-// Down to ~0.1"/px: drizzled or upscaled close-ups land well below
-// native seeing scales (an upscaled M51 solves at 0.16"/px)
-const SCALE_LADDER: &[f64] = &[0.11, 0.19, 0.35, 0.7, 1.4, 2.8, 5.6];
+/// Pixel-scale ladder, in descending order of how often real astrophotos
+/// land on each rung rather than ascending by scale: every rung a solve
+/// walks past costs a full failed attempt, so the common cases go first.
+/// Consecutive rungs are a factor of two apart and ±35 % tolerance makes
+/// them overlap, so the set still covers roughly 0.07–7.5 arcsec/pixel
+/// whatever the order.
+///
+/// - 2.8, 1.4: wide refractors and fast astrographs, the bulk of images
+/// - 0.7, 0.35: long focal lengths and SCTs
+/// - 5.6: camera lenses and wide fields
+/// - 0.19, 0.11: drizzled or upscaled close-ups, well below native seeing
+///   (an upscaled M51 solves at 0.16"/px)
+///
+/// A sidecar `pixel_scale` skips the ladder entirely — prefer setting it.
+const SCALE_LADDER: &[f64] = &[2.8, 1.4, 0.7, 5.6, 0.35, 0.19, 0.11];
 const SCALE_TOLERANCE: f64 = 0.35;
+/// A sidecar-supplied scale is trusted, but resampling and rounding move it
+/// a little, so allow a modest window around it before falling back.
+const HINTED_SCALE_TOLERANCE: f64 = 0.15;
 const SEARCH_RADIUS_DEG: f64 = 2.0;
 /// Images are downsampled to at most this many pixels on the long side
 /// before star detection (centroids are scaled back to full resolution)
@@ -649,6 +662,8 @@ async fn solve_gallery_image(
         }
     };
 
+    // A sidecar pixel scale turns the ladder walk into a single solve
+    let hint_scale = metadata.and_then(|m| m.pixel_scale).filter(|s| *s > 0.0);
     let blind_index = match hint {
         Some(_) => None,
         None => Some(astro.blind_index().await?),
@@ -656,7 +671,7 @@ async fn solve_gallery_image(
     let astro = astro.clone();
     let path_owned = path.to_string();
     let result = tokio::task::spawn_blocking(move || match (hint, blind_index) {
-        (Some(center), _) => solve_bytes(&astro, &bytes, center, &path_owned),
+        (Some(center), _) => solve_bytes(&astro, &bytes, center, hint_scale, &path_owned),
         (None, Some(index)) => solve_bytes_blind(&astro, &bytes, &index, &path_owned),
         (None, None) => None,
     })
@@ -839,19 +854,27 @@ fn solve_bytes(
     astro: &AstroContext,
     bytes: &[u8],
     hint_center: (f64, f64),
+    hint_scale: Option<f64>,
     path: &str,
 ) -> Option<crate::metadata_storage::AstroSolution> {
     let started = std::time::Instant::now();
     let (stars, (width, height)) = detect_in_bytes(bytes, path)?;
 
-    for &scale in SCALE_LADDER {
+    // The sidecar scale (when given) is one solve; the ladder is a fallback
+    // for a wrong or absent one, and each rung it walks is a failed solve
+    let attempts = hint_scale
+        .map(|scale| (scale, HINTED_SCALE_TOLERANCE))
+        .into_iter()
+        .chain(SCALE_LADDER.iter().map(|&s| (s, SCALE_TOLERANCE)));
+
+    for (scale, scale_tolerance) in attempts {
         let hint = SolveHint {
             center: hint_center,
             radius_deg: SEARCH_RADIUS_DEG,
             // Detections were rescaled to full-resolution pixels above, so
             // the ladder scale applies as-is regardless of downsampling
             scale_arcsec_px: scale,
-            scale_tolerance: SCALE_TOLERANCE,
+            scale_tolerance,
         };
         // Solve in full-resolution pixel space
         if let Ok(Solution {
@@ -903,5 +926,32 @@ mod tests {
         assert!((parse_dec("−22° 00′").unwrap() - -22.0).abs() < 1e-6);
         assert!(parse_dec("95").is_none());
         assert!(parse_dec("").is_none());
+    }
+
+    /// Reordering the ladder is only safe if the rungs still overlap: a
+    /// scale that falls in no rung's window can never solve, whatever the
+    /// order. Sorted, each rung's upper reach must meet the next's lower.
+    #[test]
+    fn scale_ladder_rungs_overlap() {
+        let mut sorted = SCALE_LADDER.to_vec();
+        sorted.sort_by(f64::total_cmp);
+        for pair in sorted.windows(2) {
+            let (low, high) = (pair[0], pair[1]);
+            assert!(
+                low * (1.0 + SCALE_TOLERANCE) >= high * (1.0 - SCALE_TOLERANCE),
+                "gap between {low} and {high}: scales in between cannot solve"
+            );
+        }
+    }
+
+    /// The common rungs come first: an image that solves at a typical
+    /// astrophoto scale must not pay for failed fine-scale attempts.
+    #[test]
+    fn scale_ladder_tries_common_scales_first() {
+        assert_eq!(SCALE_LADDER[0], 2.8);
+        assert_eq!(SCALE_LADDER[1], 1.4);
+        let fine = SCALE_LADDER.iter().position(|&s| s <= 0.2).unwrap();
+        let common = SCALE_LADDER.iter().position(|&s| s == 1.4).unwrap();
+        assert!(common < fine, "fine scales must be tried after common ones");
     }
 }


### PR DESCRIPTION
Follow-up to #277. Fixes the first-load solve latency I measured on production after the deep-catalog swap — which turned out to have nothing to do with the catalog.

## The problem

A hinted solve gets RA/Dec from the sidecar but not the pixel scale, so it walks `SCALE_LADDER` until a rung verifies. The ladder was ordered **ascending by scale** — `[0.11, 0.19, 0.35, 0.7, 1.4, 2.8, 5.6]` — but real astrophotos cluster at the *top*. A typical 2.8"/px image paid for five failed solves before reaching its rung, one of which (0.35"/px) is a 7.6s dead end. Measured on production: 13s for an image that solves in 0.53s once you hand it the right scale.

This is per-image and one-time (solutions persist to the sidecar), but it's paid on the request that first triggers the solve.

## Changes

- **`pixel_scale` in `.md` frontmatter** (arcsec/px): when set, solve once at that scale with a ±15% tolerance instead of walking the ladder at all. `206.265 × pixel size (µm) ÷ focal length (mm)`.
- **Reordered ladder** by how often images actually land on each rung: `[2.8, 1.4, 0.7, 5.6, 0.35, 0.19, 0.11]`. Same rung values, same ±35% tolerance, so coverage (~0.07–7.5"/px) is unchanged — only the order.
- Falls back to the ladder if `pixel_scale` is wrong or absent, so nothing regresses.
- Tests: rungs still overlap when sorted (a gap would make some scales unsolvable regardless of order), and common scales precede fine ones.

## Effect

Measured against the production catalog on ec2admin: the 2.8"/px rung solves in 0.53s. Images at the common scales now hit rung 1 or 2 instead of walking past the fine-scale rungs — 13s → under 1s. Setting `pixel_scale` makes it a single solve.

`cargo clippy` clean, 280 tests pass.