### PR TITLE
Adopt seiza 0.4.1 catalogs: prominence-ranked labels + LBN/Cederblad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a117df23b5465a540ca142f358c02512625cc7ef43699317b9814648a7cebf42"
+checksum = "09b3715fccd6fcae8b6be90cd0da5a97107bee1f36433c104bd8bd70c847c3be"
 dependencies = [
  "image",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = "0.3.0"
+seiza = "0.4.1"
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 

--- a/README.md
+++ b/README.md
@@ -830,7 +830,11 @@ the [seiza](https://crates.io/crates/seiza) plate-solving library:
 - **Plate Solving**: Images with RA/Dec sidecar metadata get on-demand WCS
   solutions, persisted alongside the image metadata
 - **Object Overlays**: Deep-sky objects from a catalog are overlaid on solved
-  images, with zoomable views and touch-friendly controls
+  images, with zoomable views and touch-friendly controls. Objects are ranked
+  by catalog prominence (size, brightness, whether they are named), and a
+  label-density slider trades completeness for legibility on crowded fields.
+  Named sources include NGC/IC/Messier, Sharpless/vdB, LBN, Cederblad, dark
+  nebulae, supernova remnants, and galaxies, each independently toggleable.
 - **Transient Markers**: Live markers (e.g. supernovae) from a separate
   transient catalog, scoped to each image's capture date; the catalog file is
   reloaded automatically when it changes, so a cron job can keep it fresh
@@ -838,14 +842,14 @@ the [seiza](https://crates.io/crates/seiza) plate-solving library:
   field alone, using a prebuilt whole-sky pattern index
 
 Fetch the prebuilt catalogs (`seiza download-data prebuilt --output data`, or
-straight from [downloads.seiza.fyi](https://downloads.seiza.fyi/data/manifest.json))
+straight from the [v2 bundle](https://downloads.seiza.fyi/data/v2/manifest.json))
 and point `config.toml` at them:
 
 ```toml
 [astro]
-star_data = "data/stars-deep-gaia17.bin"    # Star tiles (SEIZAST1)
+star_data = "data/stars-deep-gaia17.bin"    # Star tiles (SEIZAST2)
 blind_index = "data/blind-gaia16.idx"       # Blind pattern index (SEIZABI1, optional)
-object_data = "data/objects.bin"            # Object catalog (SEIZAOB1, optional)
+object_data = "data/objects.bin"            # Object catalog (SEIZAOB3, optional)
 transient_data = "data/transients.bin"      # Transient catalog (optional)
 minor_body_data = "data/minor-bodies.bin"   # Comets + asteroids (optional)
 ```

--- a/e2e/tests/astro-overlay.spec.ts
+++ b/e2e/tests/astro-overlay.spec.ts
@@ -124,6 +124,60 @@ test.describe('astro overlay', () => {
     await expect(svg).toHaveCount(0);
   });
 
+  test('label-density slider thins a crowded field by prominence', async ({ page }) => {
+    // A field with many ranked galaxies: prominence descends with the index.
+    const dense = {
+      solved: true,
+      width: 1600,
+      height: 1200,
+      center: { ra: 202.4, dec: 47.2 },
+      scale_arcsec_px: 1.0,
+      matched_stars: 60,
+      rms_arcsec: 0.9,
+      objects: Array.from({ length: 12 }, (_, i) => ({
+        name: `NGC ${5000 + i}`,
+        common_name: '',
+        kind: 'galaxy',
+        mag: 10 + i,
+        x: 100 + i * 110,
+        y: 200 + (i % 5) * 160,
+        semi_major_px: 30,
+        semi_minor_px: 20,
+        angle_deg: 0,
+        prominence: (12 - i) / 12,
+      })),
+    };
+    await page.route('**/api/gallery/*/astro/**', (route) => route.fulfill({ json: dense }));
+    await page.goto('/g/by-filename');
+    await page
+      .locator('.image-grid.square-grid .image-item')
+      .first()
+      .locator('a.image-link')
+      .click();
+    await expect(page).toHaveURL(/\/g\/detail\//);
+
+    await page.getByRole('button', { name: /Objects \(/ }).click();
+    const svg = page.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg).toBeVisible();
+
+    const slider = page.getByRole('slider', { name: 'Label density' });
+    await expect(slider).toBeVisible();
+
+    // At full density every galaxy is labeled...
+    await slider.fill('1');
+    await expect(svg.locator('text')).toHaveCount(12);
+
+    // ...and at the lowest density only the most prominent handful remain.
+    await slider.fill('0');
+    const low = await svg.locator('text').count();
+    expect(low).toBeLessThan(12);
+    expect(low).toBeGreaterThanOrEqual(4);
+    // The most prominent object survives; the least prominent is dropped.
+    await expect(svg.getByText('NGC 5000')).toBeVisible();
+    await expect(svg.getByText('NGC 5011')).toHaveCount(0);
+    await shot(page, 'astro-overlay-density-low');
+  });
+
   test('toggles work with taps on touch devices', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'touch-specific interaction');
     await openSolvedDetail(page);

--- a/frontend/react/__tests__/components/astro-overlay.test.ts
+++ b/frontend/react/__tests__/components/astro-overlay.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  catalogGroup,
+  partitionObjects,
+  DEFAULT_LABEL_DENSITY,
+  type AstroSolution,
+} from '../../components/ImageDetail/AstroOverlay.tsx';
+
+type Obj = NonNullable<AstroSolution['objects']>[number];
+
+function obj(partial: Partial<Obj> & { name: string }): Obj {
+  return {
+    common_name: '',
+    kind: 'galaxy',
+    x: 500,
+    y: 500,
+    semi_major_px: 20,
+    semi_minor_px: 20,
+    angle_deg: 0,
+    ...partial,
+  };
+}
+
+function solution(objects: Obj[]): AstroSolution {
+  return { solved: true, width: 2000, height: 2000, objects };
+}
+
+describe('catalogGroup', () => {
+  it('routes the new LBN and Cederblad catalogs to their own groups', () => {
+    expect(catalogGroup(obj({ name: 'LBN 468', kind: 'nebula' }))).toBe('lbn');
+    expect(catalogGroup(obj({ name: 'Ced 214', kind: 'nebula' }))).toBe('cederblad');
+    expect(catalogGroup(obj({ name: 'Ced 19c', kind: 'nebula' }))).toBe('cederblad');
+  });
+
+  it('keeps existing catalogs unchanged', () => {
+    expect(catalogGroup(obj({ name: 'NGC 7331' }))).toBe('ngc-ic-messier');
+    expect(catalogGroup(obj({ name: 'LDN 935', kind: 'dark-nebula' }))).toBe('dark-nebulae');
+    expect(catalogGroup(obj({ name: 'Sh2-101', kind: 'hii-region' }))).toBe('sharpless-vdb');
+    expect(catalogGroup(obj({ name: 'PGC 2297311' }))).toBe('pgc');
+  });
+});
+
+describe('partitionObjects density budget', () => {
+  const opts = { hiddenGroups: [] as string[], allTransients: false };
+
+  it('shows every object at full density', () => {
+    const objs = Array.from({ length: 10 }, (_, i) =>
+      obj({ name: `NGC ${i}`, prominence: i / 10 }),
+    );
+    const { rendered } = partitionObjects(solution(objs), { ...opts, density: 1 });
+    expect(rendered.length).toBe(10);
+  });
+
+  it('keeps only the most prominent named features at low density', () => {
+    const objs = Array.from({ length: 12 }, (_, i) =>
+      obj({ name: `NGC ${i}`, prominence: i / 12 }),
+    );
+    const { rendered } = partitionObjects(solution(objs), { ...opts, density: 0 });
+    // Floor of 4 at the lowest density, taken from the top of the ranking.
+    expect(rendered.length).toBe(4);
+    const proms = rendered.map((o) => o.prominence as number).sort((a, b) => b - a);
+    expect(proms[proms.length - 1]).toBeGreaterThan(0.5);
+  });
+
+  it('ranks by prominence, not catalog order', () => {
+    const objs = [
+      obj({ name: 'faint', prominence: 0.05 }),
+      obj({ name: 'bright', prominence: 0.9 }),
+      obj({ name: 'mid', prominence: 0.4 }),
+    ];
+    const { rendered } = partitionObjects(solution(objs), { ...opts, density: 0 });
+    // floor is min(3,4)=3 so all shown, but bright must sort ahead of faint
+    expect(rendered.findIndex((o) => o.name === 'bright')).toBeLessThan(
+      rendered.findIndex((o) => o.name === 'faint'),
+    );
+  });
+
+  it('always keeps transients and minor bodies regardless of density', () => {
+    const objs = [
+      ...Array.from({ length: 20 }, (_, i) => obj({ name: `NGC ${i}`, prominence: i / 20 })),
+      obj({ name: 'SN 2026abc', kind: 'transient', near_capture: true, prominence: null }),
+      obj({ name: 'C/2025 A6', kind: 'comet', prominence: null }),
+    ];
+    const { rendered } = partitionObjects(solution(objs), { ...opts, density: 0 });
+    expect(rendered.some((o) => o.kind === 'transient')).toBe(true);
+    expect(rendered.some((o) => o.kind === 'comet')).toBe(true);
+  });
+
+  it('has a sane default density that thins a crowded field', () => {
+    const objs = Array.from({ length: 30 }, (_, i) =>
+      obj({ name: `NGC ${i}`, prominence: (i % 10) / 10 }),
+    );
+    const { rendered, total } = partitionObjects(solution(objs), {
+      ...opts,
+      density: DEFAULT_LABEL_DENSITY,
+    });
+    expect(total).toBe(30);
+    expect(rendered.length).toBeGreaterThan(4);
+    expect(rendered.length).toBeLessThan(30);
+  });
+});

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -10,6 +10,8 @@ interface PlacedObject {
   semi_major_px: number;
   semi_minor_px: number;
   angle_deg: number;
+  /** Catalog prominence 0–1; absent for transients and minor bodies. */
+  prominence?: number | null;
   /** Transients only: ISO discovery date, when known */
   discovered?: string | null;
   /** Transients only: discovered near this image's capture date */
@@ -86,6 +88,8 @@ export function catalogGroup(o: PlacedObject): string {
   const name = o.name;
   if (name.startsWith('PGC')) return 'pgc';
   if (name.startsWith('UGC')) return 'ugc';
+  if (name.startsWith('LBN')) return 'lbn';
+  if (name.startsWith('Ced')) return 'cederblad';
   if (name.startsWith('LDN') || /^B\d/.test(name)) return 'dark-nebulae';
   if (name.startsWith('SNR')) return 'snr';
   if (name.startsWith('WR ')) return 'wr';
@@ -98,6 +102,8 @@ export function catalogGroup(o: PlacedObject): string {
 export const CATALOG_GROUPS: [string, string][] = [
   ['ngc-ic-messier', 'NGC / IC / Messier'],
   ['sharpless-vdb', 'Sharpless / vdB'],
+  ['lbn', 'LBN (bright nebulae)'],
+  ['cederblad', 'Cederblad'],
   ['dark-nebulae', 'Dark nebulae (B / LDN)'],
   ['snr', 'Supernova remnants'],
   ['wr', 'Wolf-Rayet stars'],
@@ -106,6 +112,44 @@ export const CATALOG_GROUPS: [string, string][] = [
   ['pgc', 'PGC galaxies'],
   ['solar-system', 'Comets / asteroids'],
 ];
+
+/** Default label density (0 = only the most prominent, 1 = every object). */
+export const DEFAULT_LABEL_DENSITY = 0.6;
+/** Below this many rankable objects, the density control adds nothing. */
+const DENSITY_FLOOR = 4;
+
+/**
+ * Split the field into the objects to label and the frame-filling ones shown
+ * as a "Field within" caption. Prominence (from the catalog) ranks the named
+ * features so a density budget can keep wide fields legible: transients and
+ * minor bodies have no prominence and are always kept. Shared by the overlay
+ * and the controls so the button count matches what is drawn.
+ */
+export function partitionObjects(
+  solution: AstroSolution,
+  opts: { hiddenGroups: string[]; allTransients: boolean; density: number },
+): { rendered: PlacedObject[]; encompassing: PlacedObject[]; total: number } {
+  const { width, height } = solution;
+  const everything = (solution.objects || []).filter(
+    (o) => !opts.hiddenGroups.includes(catalogGroup(o)),
+  );
+  const distant = distantTransients(solution).filter((o) => everything.includes(o));
+  const all = opts.allTransients ? everything : everything.filter((o) => !distant.includes(o));
+  const encompassing = all.filter((o) => encompassesFrame(o, width, height));
+  const inFrame = all.filter((o) => !encompassing.includes(o));
+
+  const rankable = inFrame
+    .filter((o) => o.prominence != null)
+    .sort((a, b) => (b.prominence as number) - (a.prominence as number));
+  const unrankable = inFrame.filter((o) => o.prominence == null);
+
+  const floor = Math.min(rankable.length, DENSITY_FLOOR);
+  const budget = Math.round(floor + (rankable.length - floor) * opts.density);
+  // Unrankable (transients / comets) first so their labels win collisions,
+  // then the most prominent named features up to the density budget.
+  const rendered = [...unrankable, ...rankable.slice(0, Math.max(floor, budget))];
+  return { rendered, encompassing, total: inFrame.length };
+}
 
 /** Transients not discovered near the capture date (hidden by default). */
 export function distantTransients(solution: AstroSolution): PlacedObject[] {
@@ -120,6 +164,8 @@ interface AstroOverlayProps {
   allTransients: boolean;
   /** Catalog groups (see [`catalogGroup`]) currently hidden */
   hiddenGroups?: string[];
+  /** Label density 0–1: fewer, most-prominent labels → every object. */
+  density?: number;
 }
 
 /** The SVG marker layer. Toggle buttons live in [`AstroControls`]. */
@@ -128,19 +174,18 @@ export function AstroOverlay({
   visible,
   allTransients,
   hiddenGroups = [],
+  density = DEFAULT_LABEL_DENSITY,
 }: AstroOverlayProps) {
 
-  const width = solution.width;
   const height = solution.height;
-  // Transients not discovered near the capture date are noise by default
-  // (M31 accumulates hundreds of historical novae) but can be toggled on
-  const everything = (solution.objects || []).filter(
-    (o) => !hiddenGroups.includes(catalogGroup(o)),
-  );
-  const distant = distantTransients(solution).filter((o) => everything.includes(o));
-  const all = allTransients ? everything : everything.filter((o) => !distant.includes(o));
-  const encompassing = all.filter((o) => encompassesFrame(o, width, height));
-  const objects = all.filter((o) => !encompassing.includes(o));
+  // Prominence-ranked, density-budgeted labels; frame-filling objects become
+  // a caption instead. Transients far from the capture date stay hidden
+  // unless allTransients is set (M31 accumulates hundreds of historical novae).
+  const { rendered: objects, encompassing } = partitionObjects(solution, {
+    hiddenGroups,
+    allTransients,
+    density,
+  });
   const stroke = Math.max(solution.width / 1200, 1.5);
   const fontSize = Math.max(solution.width / 70, 14);
 
@@ -303,6 +348,8 @@ interface AstroControlsProps {
   onAllTransientsChange: (all: boolean) => void;
   hiddenGroups: string[];
   onHiddenGroupsChange: (groups: string[]) => void;
+  density: number;
+  onDensityChange: (density: number) => void;
 }
 
 /**
@@ -317,14 +364,26 @@ export function AstroControls({
   onAllTransientsChange,
   hiddenGroups,
   onHiddenGroupsChange,
+  density,
+  onDensityChange,
 }: AstroControlsProps) {
   const objects = solution.objects || [];
-  const kept = objects.filter((o) => !hiddenGroups.includes(catalogGroup(o)));
-  const distant = distantTransients(solution).filter((o) => kept.includes(o));
-  const shown = allTransients ? kept.length : kept.length - distant.length;
+  const { rendered, total } = partitionObjects(solution, {
+    hiddenGroups,
+    allTransients,
+    density,
+  });
+  const shown = rendered.length;
+  const distant = distantTransients(solution).filter(
+    (o) => !hiddenGroups.includes(catalogGroup(o)),
+  );
   const availableGroups = CATALOG_GROUPS.filter(([id]) =>
     objects.some((o) => catalogGroup(o) === id),
   );
+  // The density control only matters when it can hide something.
+  const rankableTotal = objects.filter(
+    (o) => o.prominence != null && !hiddenGroups.includes(catalogGroup(o)),
+  ).length;
 
   return (
     <div className="control-buttons astro-controls">
@@ -332,7 +391,7 @@ export function AstroControls({
         type="button"
         className={`btn ${visible ? 'btn-primary' : 'btn-secondary'}`}
         onClick={() => onVisibleChange(!visible)}
-        title={`${shown} objects — solved at ${solution.scale_arcsec_px?.toFixed(2)}″/px`}
+        title={`${shown} of ${total} objects — solved at ${solution.scale_arcsec_px?.toFixed(2)}″/px`}
       >
         {visible ? 'Objects ✕' : `Objects (${shown})`}
       </button>
@@ -345,6 +404,24 @@ export function AstroControls({
         >
           {allTransients ? 'Hide old transients' : `+${distant.length} old transients`}
         </button>
+      )}
+      {visible && rankableTotal > DENSITY_FLOOR && (
+        <label
+          className="astro-density"
+          title={`Label density — showing ${shown} of ${total}`}
+        >
+          <span aria-hidden="true">Fewer</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={density}
+            onChange={(e) => onDensityChange(Number(e.target.value))}
+            aria-label="Label density"
+          />
+          <span aria-hidden="true">More</span>
+        </label>
       )}
       {visible && availableGroups.length > 1 && (
         <CatalogMenu

--- a/frontend/react/pages/image-detail.tsx
+++ b/frontend/react/pages/image-detail.tsx
@@ -12,7 +12,12 @@ import { MobileNavigation } from '../components/ImageDetail/MobileNavigation.tsx
 import { VersionPicker } from '../components/ImageDetail/VersionPicker.tsx';
 import { ImageMetadata, CameraMetadata, LocationMetadata, AIMetadata } from '../components/ImageDetail/ImageMetadata.tsx';
 import { AstroSkyMap } from '../components/ImageDetail/AstroSkyMap.tsx';
-import { AstroControls, AstroOverlay, useAstroSolution } from '../components/ImageDetail/AstroOverlay.tsx';
+import {
+  AstroControls,
+  AstroOverlay,
+  DEFAULT_LABEL_DENSITY,
+  useAstroSolution,
+} from '../components/ImageDetail/AstroOverlay.tsx';
 import { UserMetadata } from '../components/ImageDetail/UserMetadata.tsx';
 import { ImageControls } from '../components/ImageDetail/ImageControls.tsx';
 import { EditModal } from '../components/Editor/index.ts';
@@ -131,6 +136,18 @@ export function ImageDetailPage({
     setAstroHiddenGroupsState(groups);
     try {
       localStorage.setItem('astro-hidden-catalogs', JSON.stringify(groups));
+    } catch {
+      /* private mode */
+    }
+  };
+  const [astroDensity, setAstroDensityState] = useState<number>(() => {
+    const stored = Number(localStorage.getItem('astro-label-density'));
+    return Number.isFinite(stored) && stored > 0 ? stored : DEFAULT_LABEL_DENSITY;
+  });
+  const setAstroDensity = (density: number) => {
+    setAstroDensityState(density);
+    try {
+      localStorage.setItem('astro-label-density', String(density));
     } catch {
       /* private mode */
     }
@@ -295,6 +312,7 @@ export function ImageDetailPage({
                       visible={astroVisible}
                       allTransients={astroAllTransients}
                       hiddenGroups={astroHiddenGroups}
+                      density={astroDensity}
                     />
                   ) : undefined
                 }
@@ -305,6 +323,7 @@ export function ImageDetailPage({
                       visible
                       allTransients={astroAllTransients}
                       hiddenGroups={astroHiddenGroups}
+                      density={astroDensity}
                     />
                   ) : undefined
                 }
@@ -322,6 +341,8 @@ export function ImageDetailPage({
               onAllTransientsChange={setAstroAllTransients}
               hiddenGroups={astroHiddenGroups}
               onHiddenGroupsChange={setAstroHiddenGroups}
+              density={astroDensity}
+              onDensityChange={setAstroDensity}
             />
           )}
 

--- a/frontend/react/pages/post-astro-overlay.tsx
+++ b/frontend/react/pages/post-astro-overlay.tsx
@@ -4,6 +4,7 @@ import {
   AstroOverlay,
   AstroSolution,
   CatalogMenu,
+  DEFAULT_LABEL_DENSITY,
   distantTransients,
   catalogGroup,
   useAstroSolution,
@@ -26,6 +27,12 @@ function loadHiddenGroups(): string[] {
   } catch {
     return [];
   }
+}
+
+/** Embeds have no density control; they honor the detail page's setting. */
+function loadDensity(): number {
+  const stored = Number(localStorage.getItem('astro-label-density'));
+  return Number.isFinite(stored) && stored > 0 ? stored : DEFAULT_LABEL_DENSITY;
 }
 
 const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, path }) => {
@@ -114,6 +121,7 @@ const EmbedOverlay: React.FC<{ gallery: string; path: string }> = ({ gallery, pa
             visible
             allTransients={false}
             hiddenGroups={hiddenGroups}
+            density={loadDensity()}
           />
         </span>
       )}

--- a/static/image-detail.css
+++ b/static/image-detail.css
@@ -432,6 +432,36 @@ body {
     }
 }
 
+/* Label-density slider: prominence-ranks how many named features are shown */
+.astro-density {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.15rem 0.75rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-color, rgba(128, 128, 128, 0.4));
+    background: var(--bg-secondary, rgba(128, 128, 128, 0.12));
+    font-size: 0.72rem;
+    color: var(--text-secondary, #999);
+    touch-action: manipulation;
+}
+
+.astro-density input[type='range'] {
+    width: 6rem;
+    accent-color: var(--link-color, #4a9eff);
+    cursor: pointer;
+}
+
+@media (pointer: coarse) {
+    .astro-density {
+        min-height: 44px;
+    }
+    .astro-density input[type='range'] {
+        width: 8rem;
+        height: 24px;
+    }
+}
+
 /* Per-catalog dropdown: a pill-styled popover above the toggle */
 .astro-catalog-menu {
     position: absolute;

--- a/tenrankai-metadata/src/types.rs
+++ b/tenrankai-metadata/src/types.rs
@@ -444,4 +444,9 @@ pub struct AstroObject {
     pub semi_major_px: f64,
     pub semi_minor_px: f64,
     pub angle_deg: f64,
+    /// Catalog prominence 0–1 (size/brightness/naming heuristic from seiza);
+    /// drives which named features are labeled first. Absent for transients
+    /// and minor bodies, which are ranked by recency and motion instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prominence: Option<f32>,
 }

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -181,7 +181,11 @@ impl AstroContext {
             Some(path) => match ObjectCatalog::open(path) {
                 Ok(catalog) => {
                     let bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
-                    objects_version = format!("{}:{}", catalog.len(), bytes);
+                    // The `p2` schema tag bumps whenever the persisted overlay
+                    // shape changes (here: added prominence), forcing a
+                    // one-time reprojection even if the catalog file is
+                    // unchanged.
+                    objects_version = format!("p2:{}:{}", catalog.len(), bytes);
                     info!(
                         "astro: {} objects loaded from {} (version {objects_version})",
                         catalog.len(),
@@ -435,6 +439,7 @@ async fn solution_response(
                 "semi_major_px": o.semi_major_px,
                 "semi_minor_px": o.semi_minor_px,
                 "angle_deg": o.angle_deg,
+                "prominence": o.prominence,
             })
         })
         .collect();
@@ -445,7 +450,13 @@ async fn solution_response(
     // default (M31 alone accumulates hundreds of historical novae).
     if let Some(transients) = &astro.transients {
         let catalog = transients.current().await;
-        for p in catalog.objects_in_footprint(&wcs, dims) {
+        let placed = catalog
+            .objects_in_footprint(&wcs, dims)
+            .unwrap_or_else(|e| {
+                warn!("astro: transient footprint query failed: {e}");
+                Vec::new()
+            });
+        for p in placed {
             let discovered = transient_discovery_date(&p.object.common_name);
             let near_capture = match (&discovered, capture_date) {
                 (Some(date), Some(capture)) => chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d")
@@ -729,10 +740,18 @@ pub(crate) fn placed_objects(
         .objects
         .as_ref()
         .map(|catalog| {
-            catalog
-                .objects_in_footprint(wcs, dims)
+            let placed = catalog.objects_in_footprint(wcs, dims).unwrap_or_else(|e| {
+                warn!("astro: object footprint query failed: {e}");
+                Vec::new()
+            });
+            // objects_in_footprint gives placement but drops the catalog
+            // prominence; a second query over the same footprint recovers it,
+            // joined by name (unique within the catalog).
+            let prominence = object_prominence(catalog, wcs, dims);
+            placed
                 .into_iter()
                 .map(|p| crate::metadata_storage::AstroObject {
+                    prominence: prominence.get(p.object.name.as_str()).copied(),
                     name: p.object.name,
                     common_name: p.object.common_name,
                     kind: p.object.kind.as_str().to_string(),
@@ -743,6 +762,28 @@ pub(crate) fn placed_objects(
                     semi_minor_px: p.semi_minor_px,
                     angle_deg: p.angle_deg,
                 })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Catalog prominence (0–1) keyed by object name for the image footprint.
+/// `objects_in_footprint` computes this internally but returns only placement,
+/// so we re-run the region query to keep the ranking without duplicating the
+/// projection math.
+fn object_prominence(
+    catalog: &ObjectCatalog,
+    wcs: &Wcs,
+    dims: (u32, u32),
+) -> std::collections::HashMap<String, f32> {
+    let region = seiza::objects::SkyRegion::Polygon {
+        vertices: wcs.footprint(dims.0, dims.1).to_vec(),
+    };
+    catalog
+        .query_region(&region, &seiza::objects::ObjectQuery::default())
+        .map(|hits| {
+            hits.into_iter()
+                .map(|h| (h.object.name, h.predicted_prominence as f32))
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
Updates tenrankai to **seiza 0.4.1** (seiza-fits 0.1.4) and wires up its richer object catalog.

## What seiza 0.4.1 brings
- Objects now carry a **prominence** score (0–1: size, brightness, whether they're named), plus coordinate-only region queries and richer metadata (stable IDs, aliases, more named sources incl. LBN and Cederblad).
- Hosted data moved to the versioned **v2 bundle** (`/data/v2`), whose `objects.bin` is the extended SEIZAOB3 format (315k objects, 62 MB vs the old 14 MB). `open()` still reads legacy files, so nothing breaks mid-deploy.

## Changes
- **Dep bump + API:** `ObjectCatalog::objects_in_footprint` now returns `Result`; handled at both call sites.
- **Prominence through to the UI:** each persisted overlay object gains a `prominence` field, joined from a `query_region` pass over the same footprint (`objects_in_footprint` returns placement only). Transients/minor bodies have none and keep their recency/motion ranking.
- **Label density:** prominence orders label-collision priority and drives a **density slider** that budgets how many named features are drawn — wide, crowded fields stay legible instead of a wall of labels. The setting persists in `localStorage` and post embeds honor it (no control, just the stored value).
- **New catalogs:** LBN (bright nebulae) and Cederblad get their own toggle groups alongside the existing ones.
- **One-time reprojection:** the persisted-overlay schema tag bumps to `p2:`, so existing sidecars reproject once on deploy to gain prominence.

## UX decisions
Confirmed with the maintainer: prominence drives **auto-ranking + an explicit density control** (not silent-only), and LBN/Cederblad get **their own toggle groups** (not folded into a generic nebulae bucket).

## Tests
- `partitionObjects` density-budget logic + new catalog grouping (7 vitest cases).
- A new e2e that mocks a 12-galaxy field and checks the density slider thins it from 12 labels down to the most-prominent handful.
- Existing astro overlay suite unchanged and green (the mocked fixture has no prominence, so counts and the transient toggles are unaffected).
- `cargo clippy` clean, 280 rust tests + 89 frontend tests pass; astro e2e 7/7 (+2 touch skipped) on chromium.

## Deploy note
Production must fetch the new v2 `objects.bin` (`seiza download-data prebuilt --file objects.bin`) — the extended catalog is what carries the new named sources and feeds prominence. ec2admin already runs seiza 0.4.1; its local `objects.bin` is still the old 14 MB one.