### PR TITLE
Fix Security audit CI: --locked cargo-audit install + anyhow bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,10 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Install cargo-audit
-      run: cargo install cargo-audit
+      # --locked installs the versions from cargo-audit's own lockfile; without
+      # it, cargo resolves transitive deps (e.g. kstring) to releases whose
+      # MSRV outruns the runner's stable toolchain and the build fails.
+      run: cargo install cargo-audit --locked
 
     - name: Run cargo audit
       run: cargo audit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,11 +30,14 @@ jobs:
           key: ${{ runner.os }}-cargo-audit
       
       - name: Install or update cargo-audit
+        # --locked pins cargo-audit's own tested dependency versions; without
+        # it, a transitive dep (e.g. kstring) resolves to a release whose MSRV
+        # exceeds the runner's stable toolchain and the build fails.
         run: |
           if ! command -v cargo-audit &> /dev/null; then
-            cargo install cargo-audit --features=fix
+            cargo install cargo-audit --locked --features=fix
           else
-            cargo install cargo-audit --features=fix --force
+            cargo install cargo-audit --locked --features=fix --force
           fi
       
       - name: Run security audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "anymap2"


### PR DESCRIPTION
The **Security audit** CI job has been failing on every PR (and on `main`) — unrelated to the changes in those PRs.

## Root cause
`cargo install cargo-audit` builds cargo-audit from source. Without a lockfile it resolves transitive dependencies to their newest compatible releases, and one of them — `kstring 2.0.3` — bumped its MSRV to **rustc 1.96.0**. The CI runner's stable toolchain is **1.94.1**, so the build fails:

```
error: failed to compile `cargo-audit v0.22.2`
  rustc 1.94.1 is not supported by the following package:
    kstring@2.0.3 requires rustc 1.96.0
```

## Fix
Add `--locked` to both `cargo install cargo-audit` invocations (`ci.yml` and `security.yml`). `--locked` installs the exact versions from cargo-audit's own committed lockfile, which predate the kstring MSRV bump. This is the documented remedy for "a transitive dependency requires a newer rustc than the toolchain."

Verified locally on the same toolchain the runner uses:
- `rustc 1.94.1` + `cargo install cargo-audit --locked --force` → compiles in ~1 min (previously failed).
- `cargo audit` → exits 0 (4 pre-existing transitive `unmaintained`/`yanked` warnings, none fail the run).

## Also
Bump `anyhow` 1.0.102 → 1.0.103, which clears **RUSTSEC-2026-0192** (unsoundness in `Error::downcast_mut()`) — a fresh advisory surfaced once the audit could actually run. Clean patch bump; backend builds.

The remaining warnings (`rustybuzz`/`ttf-parser` unmaintained, `spin` yanked) are transitive and non-failing; left as-is.