### PR TITLE
Remove stray Playwright test-results artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ TODO.md
 /static/dist/
 static/admin/
 .cache/
+
+# Playwright artifacts from bare runs
+test-results/

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}


### PR DESCRIPTION
Removes `test-results/.last-run.json` (accidentally committed in #281 from a bare `playwright test` run) and gitignores the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)