### PR TITLE
Adopt @seiza/astro-overlay 0.3.0 suggested catalog palette

### DIFF
--- a/e2e/tests/astro-overlay.spec.ts
+++ b/e2e/tests/astro-overlay.spec.ts
@@ -239,6 +239,51 @@ test.describe('astro overlay', () => {
     await shot(page, 'astro-overlay-outlines-off');
   });
 
+  test('deep-sky markers are colored by catalog family', async ({ page }) => {
+    // One object per catalog family; stars keep the theme color.
+    const mixed = {
+      ...SOLUTION,
+      objects: [
+        { ...SOLUTION.objects[0] },
+        { ...SOLUTION.objects[0], name: 'M 31', x: 150, y: 100 },
+        { ...SOLUTION.objects[0], name: 'IC 5070', kind: 'nebula', x: 650, y: 100 },
+        { ...SOLUTION.objects[0], name: 'Sh2-101', kind: 'nebula', x: 650, y: 500 },
+        { ...SOLUTION.objects[1] },
+      ],
+    };
+    await page.route('**/api/gallery/*/astro/**', (route) =>
+      route.fulfill({ json: mixed }),
+    );
+    await page.goto('/g/by-filename');
+    await page
+      .locator('.image-grid.square-grid .image-item')
+      .first()
+      .locator('a.image-link')
+      .click();
+    await expect(page).toHaveURL(/\/g\/detail\//);
+
+    await page.getByRole('button', { name: /Objects \(/ }).click();
+    const svg = page.locator('svg[aria-label="Sky object overlay"]');
+    await expect(svg).toBeVisible();
+
+    // The suggested seiza palette separates catalogs by color, applied to
+    // marker and label alike (no CSS override may flatten the labels)
+    const labelFill = (name: string) =>
+      svg.locator('.seiza-overlay__label', { hasText: name }).getAttribute('fill');
+    expect(await labelFill('NGC 224')).toBe('#55cfff');
+    expect(await labelFill('M 31')).toBe('#f2ca72');
+    expect(await labelFill('IC 5070')).toBe('#72dfb9');
+    expect(await labelFill('Sh2-101')).toBe('#ee9a78');
+    const ngcGroup = svg.locator('g[data-kind="galaxy"]', { hasText: 'NGC 224' });
+    await expect(ngcGroup.locator('.seiza-overlay__marker')).toHaveAttribute(
+      'stroke',
+      '#55cfff',
+    );
+    // The WR star is not a deep-sky object: it stays on the theme color
+    expect(await labelFill('WR 134')).toContain('var(');
+    await shot(page, 'astro-overlay-catalog-colors');
+  });
+
   test('toggles work with taps on touch devices', async ({ page, isMobile }) => {
     test.skip(!isMobile, 'touch-specific interaction');
     await openSolvedDetail(page);

--- a/frontend/react/components/ImageDetail/AstroOverlay.tsx
+++ b/frontend/react/components/ImageDetail/AstroOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
   partitionOverlayObjects,
+  suggestedDeepSkyColorForObject,
   type OverlayLayerVisibility,
   type OverlayObject,
 } from '@seiza/astro-overlay';
@@ -196,6 +197,7 @@ export function AstroOverlay({
       layers={ALL_LAYERS}
       density={density}
       minimumRankedObjects={DENSITY_FLOOR}
+      colorForObject={suggestedDeepSkyColorForObject}
       showCenter={false}
       aria-label="Sky object overlay"
       style={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "tenrankai-frontend",
       "dependencies": {
-        "@seiza/astro-overlay": "0.2.0",
+        "@seiza/astro-overlay": "^0.3.0",
         "@tiptap/core": "^3.22.5",
         "@tiptap/extension-image": "^3.27.1",
         "@tiptap/extension-link": "^3.23.6",
@@ -984,9 +984,9 @@
       "license": "MIT"
     },
     "node_modules/@seiza/astro-overlay": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@seiza/astro-overlay/-/astro-overlay-0.2.0.tgz",
-      "integrity": "sha512-lh7HuQrS+vfzAmDiU73wzzfiQUBKPZm47awzh4vDAtzwHxz3vmZihkdxPp5djg34RWOJgRRBA3WfGtj3biQfyA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@seiza/astro-overlay/-/astro-overlay-0.3.0.tgz",
+      "integrity": "sha512-/bDdLpi+I+5jm3dd1FIE1Pq8JZiwtjL1uTGQqpV22jUQGBvc4qB+Z8LgaKWrhTI8q0E5MCUtwbXZEpgngIjU3Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "help": "echo 'Development: npm run dev (+ cargo run in another terminal)'"
   },
   "dependencies": {
-    "@seiza/astro-overlay": "0.2.0",
+    "@seiza/astro-overlay": "^0.3.0",
     "@tiptap/core": "^3.22.5",
     "@tiptap/extension-image": "^3.27.1",
     "@tiptap/extension-link": "^3.23.6",

--- a/static/image-detail.css
+++ b/static/image-detail.css
@@ -522,12 +522,6 @@ body {
     border-radius: 0;
 }
 
-/* The packaged overlay labels deep-sky objects in the marker color;
-   production has always used a softer blue for those labels */
-.seiza-overlay g[data-layer='deep_sky'] .seiza-overlay__label {
-    fill: #aee8ff;
-}
-
 .nav-hint-container {
     margin-top: var(--spacing-sm);
 }


### PR DESCRIPTION
## Summary

- Upgrade `@seiza/astro-overlay` 0.2.0 → 0.3.0 and opt into its new suggested deep-sky catalog palette via the `colorForObject` resolver: deep-sky ellipses, precise outlines, and labels are now colored by catalog family (Messier gold, NGC blue, IC teal, Sharpless/vdB orange, LBN green, Cederblad cyan, dark nebulae purple, SNR red, UGC/PGC blues) for much better visual separation in busy fields.
- Stars, transients, comets, and asteroids keep their existing theme colors — the resolver returns `undefined` for non-deep-sky kinds.
- Controls are unchanged: same catalog menu, density slider, transient and precise-outline toggles.
- Removed the CSS rule that pinned all deep-sky labels to one blue; it would have overridden the per-catalog label colors (the package emits them as SVG presentation attributes, which CSS beats).
- New e2e test asserts the per-family marker/label colors and that stars remain theme-colored.

## Before / after

Same corpus and viewport as #281; before is what production renders today.

| Field | Before (uniform deep-sky blue) | After (catalog palette) |
|---|---|---|
| NGC 7000 / IC 5070 | ![before](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/after/ngc7000.png) | ![after](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/palette/ngc7000.png) |
| M31 | ![before](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/after/m31.png) | ![after](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/palette/m31.png) |
| NGC 7331 | ![before](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/after/ngc7331.png) | ![after](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/palette/ngc7331.png) |
| Crescent | ![before](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/after/crescent.png) | ![after](https://raw.githubusercontent.com/theatrus/tenrankai/307caea392ac5ec64962576ae55a669ab4c06ecf/palette/crescent.png) |

## Test plan

- [x] `npm run lint` + vitest (89 passed)
- [x] `npm run test:e2e -- astro-overlay.spec` — 19 passed incl. the new catalog-color test
- [x] Frontend-only change; no Rust modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)