### PR TITLE
Add [astro] data directory key resolved through seiza 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,6 +1462,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2874,6 +2895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3427,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "outref"
@@ -3960,6 +3996,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4187,7 +4234,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4244,7 +4291,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4367,10 +4414,11 @@ dependencies = [
 
 [[package]]
 name = "seiza"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254c2c01c7c1f26f6a848234ec9e53f04e5b47afd821f75ef061b7568ace62a0"
+checksum = "9ae20be7b2b87b9d5d737f05c3d222818b8d164a2b406675f381386758f44694"
 dependencies = [
+ "directories",
  "image",
  "memmap2",
  "multiversion",
@@ -4987,7 +5035,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6132,7 +6180,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ tenrankai-config-storage = { path = "tenrankai-config-storage" }
 tenrankai-email = { path = "tenrankai-email" }
 tenrankai-image = { path = "tenrankai-image" }
 tenrankai-metadata = { path = "tenrankai-metadata" }
-seiza = "0.6.0"
+seiza = "0.8.0"
 tenrankai-storage = { path = "tenrankai-storage" }
 tenrankai-users = { path = "tenrankai-users" }
 

--- a/README.md
+++ b/README.md
@@ -852,12 +852,28 @@ and point `config.toml` at them:
 
 ```toml
 [astro]
-star_data = "data/stars-deep-gaia17.bin"    # Star tiles (SEIZAST2)
+data = "data"     # One directory with every catalog; seiza picks the files
+```
+
+`data` resolves like the seiza CLI's `--data`: the deepest star catalog in
+the directory wins, and the blind index, object, transient, and minor-body
+catalogs are picked up when present. Every kind also has an explicit key
+that overrides the directory:
+
+```toml
+[astro]
+data = "data"
+star_data = "data/stars-lite-tycho2.bin"    # Star tiles (SEIZAST2)
 blind_index = "data/blind-gaia16.idx"       # Blind pattern index (SEIZABI1, optional)
 object_data = "data/objects.bin"            # Object catalog (v4/SEIZAOB, optional)
 transient_data = "data/transients.bin"      # Transient catalog (optional)
 minor_body_data = "data/minor-bodies.bin"   # Comets + asteroids (optional)
 ```
+
+With neither `data` nor `star_data` set, the star catalog and blind index
+are searched for in seiza's standard locations (`SEIZA_STAR_DATA`,
+`SEIZA_BLIND_INDEX`, the `seiza setup` directories); the annotation
+catalogs stay off unless configured.
 
 `blind_index` is memory-mapped at first use and must come from the same
 catalog as `star_data`. Without it the index is built on demand from

--- a/tenrankai/src/astro.rs
+++ b/tenrankai/src/astro.rs
@@ -157,13 +157,27 @@ impl AstroContext {
 
     /// Load catalogs from the configured data files. Returns None (with a
     /// warning) when loading fails so a bad path cannot take the site down.
+    ///
+    /// Paths resolve through `seiza::data_paths`: an explicit per-kind key
+    /// wins, then the shared `data` directory, and the star catalog and
+    /// blind index also fall back to seiza's standard locations. The
+    /// annotation catalogs are optional — absent from the `data` directory
+    /// just means that layer stays off.
     pub fn load(config: &crate::config::AstroConfig) -> Option<Arc<Self>> {
-        let stars = match TileCatalog::open(&config.star_data) {
+        let data = config.data.as_deref();
+        let star_path = match seiza::data_paths::star_data(config.star_data.as_deref().or(data)) {
+            Ok(path) => path,
+            Err(e) => {
+                warn!("astro: {e}; plate solving disabled");
+                return None;
+            }
+        };
+        let stars = match TileCatalog::open(&star_path) {
             Ok(catalog) => {
                 info!(
                     "astro: {} stars loaded from {} (epoch {})",
                     catalog.star_count(),
-                    config.star_data.display(),
+                    star_path.display(),
                     catalog.epoch()
                 );
                 catalog
@@ -171,13 +185,36 @@ impl AstroContext {
             Err(e) => {
                 warn!(
                     "astro: failed to open star data {}: {e}; plate solving disabled",
-                    config.star_data.display()
+                    star_path.display()
                 );
                 return None;
             }
         };
+        let blind_index_path =
+            match seiza::data_paths::blind_index(config.blind_index.as_deref().or(data)) {
+                Ok(path) => path,
+                Err(e) => {
+                    warn!("astro: {e}; blind solving will build an in-memory bright index");
+                    None
+                }
+            };
+        let object_path = optional_catalog(
+            config.object_data.as_deref(),
+            data,
+            seiza::data_paths::objects,
+        );
+        let transient_path = optional_catalog(
+            config.transient_data.as_deref(),
+            data,
+            seiza::data_paths::transients,
+        );
+        let minor_body_path = optional_catalog(
+            config.minor_body_data.as_deref(),
+            data,
+            seiza::data_paths::minor_bodies,
+        );
         let mut objects_version = String::new();
-        let objects = match &config.object_data {
+        let objects = match &object_path {
             Some(path) => match ObjectCatalog::open(path) {
                 Ok(catalog) => {
                     let bytes = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
@@ -200,14 +237,14 @@ impl AstroContext {
             },
             None => None,
         };
-        let transients = config.transient_data.as_deref().and_then(|path| {
+        let transients = transient_path.as_deref().and_then(|path| {
             let catalog = ReloadingCatalog::open(path);
             if catalog.is_none() {
                 warn!("astro: failed to open transient data {}", path.display());
             }
             catalog
         });
-        let minor_bodies = config.minor_body_data.as_deref().and_then(|path| {
+        let minor_bodies = minor_body_path.as_deref().and_then(|path| {
             let catalog = ReloadingMinorBodies::open(path);
             match &catalog {
                 Some(c) => info!(
@@ -225,11 +262,34 @@ impl AstroContext {
             objects,
             objects_version,
             transients,
-            blind_index_path: config.blind_index.clone(),
+            blind_index_path,
             blind_index: tokio::sync::OnceCell::new(),
             minor_bodies,
             failed: RwLock::new(HashMap::new()),
         }))
+    }
+}
+
+/// Resolve an optional annotation catalog: an explicit key must resolve
+/// (a warning disables the layer), the shared `data` directory is searched
+/// quietly, and with neither the layer stays off.
+fn optional_catalog(
+    explicit: Option<&std::path::Path>,
+    data: Option<&std::path::Path>,
+    resolve: impl Fn(
+        Option<&std::path::Path>,
+    ) -> Result<std::path::PathBuf, seiza::data_paths::DataPathError>,
+) -> Option<std::path::PathBuf> {
+    match (explicit, data) {
+        (Some(path), _) => match resolve(Some(path)) {
+            Ok(path) => Some(path),
+            Err(e) => {
+                warn!("astro: {e}");
+                None
+            }
+        },
+        (None, Some(dir)) => resolve(Some(dir)).ok(),
+        (None, None) => None,
     }
 }
 
@@ -361,6 +421,7 @@ pub async fn astro_handler(
                 crval: (solution.crval[0], solution.crval[1]),
                 crpix: (solution.crpix[0], solution.crpix[1]),
                 cd: solution.cd,
+                sip: None,
             };
             let mut updated = solution.clone();
             updated.objects = placed_objects(&astro, &wcs, (solution.width, solution.height));
@@ -420,6 +481,7 @@ async fn solution_response(
         crval: (solution.crval[0], solution.crval[1]),
         crpix: (solution.crpix[0], solution.crpix[1]),
         cd: solution.cd,
+        sip: None,
     };
     let dims = (solution.width, solution.height);
     let (center_ra, center_dec) = wcs.pixel_to_world(dims.0 as f64 / 2.0, dims.1 as f64 / 2.0);
@@ -974,6 +1036,9 @@ fn solve_bytes(
             // the ladder scale applies as-is regardless of downsampling
             scale_arcsec_px: scale,
             scale_tolerance,
+            // The persisted sidecar schema stores a linear WCS; SIP terms
+            // would be lost, so the overlay solves stay linear
+            sip_order: 0,
         };
         // Solve in full-resolution pixel space
         if let Ok(Solution {

--- a/tenrankai/src/commands/astro.rs
+++ b/tenrankai/src/commands/astro.rs
@@ -65,6 +65,7 @@ pub async fn handle_regen_command(
             crval: (solution.crval[0], solution.crval[1]),
             crpix: (solution.crpix[0], solution.crpix[1]),
             cd: solution.cd,
+            sip: None,
         };
         let mut updated = solution.clone();
         updated.objects =

--- a/tenrankai/src/config/types.rs
+++ b/tenrankai/src/config/types.rs
@@ -26,11 +26,26 @@ pub struct Config {
 }
 
 /// Plate-solving data configuration (`[astro]`).
+///
+/// Paths resolve through `seiza::data_paths`, the same rules as the seiza
+/// CLI's `--data`: each key takes a file or a directory (a directory picks
+/// the right catalog inside). `data` names one directory for everything;
+/// the per-kind keys override it. With neither `data` nor `star_data` set,
+/// the star catalog and blind index are searched for in seiza's standard
+/// locations (`SEIZA_STAR_DATA`, `SEIZA_BLIND_INDEX`, `seiza setup`
+/// directories); the annotation catalogs stay disabled unless configured.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AstroConfig {
-    /// Star tile file built by `seiza build-data` (SEIZAST1)
-    pub star_data: std::path::PathBuf,
+    /// Directory holding every catalog (star tiles, blind index, objects,
+    /// transients, minor bodies), e.g. the `seiza download-data prebuilt`
+    /// output directory
+    #[serde(default)]
+    pub data: Option<std::path::PathBuf>,
+    /// Star tile catalog built by `seiza build-data` (SEIZAST1);
+    /// overrides `data`
+    #[serde(default)]
+    pub star_data: Option<std::path::PathBuf>,
     /// Prebuilt blind pattern index built by `seiza build-blind-index`
     /// (SEIZABI1), memory-mapped at startup. Without it the index is built
     /// from `star_data` on the first blind solve, which only covers the


### PR DESCRIPTION
## Summary

- Bump seiza 0.6.0 → 0.8.0 and add an optional `data` key to `[astro]`: one directory holding every catalog, resolved through the new `seiza::data_paths` library API with the same rules as the seiza CLI's `--data` (deepest star catalog wins; blind index, objects, transients, and minor bodies picked up when present).
- The five per-file keys (`star_data`, `blind_index`, `object_data`, `transient_data`, `minor_body_data`) remain and override the directory per kind. `star_data` is no longer required.
- With neither `data` nor `star_data`, the star catalog and blind index fall back to seiza's standard locations (`SEIZA_STAR_DATA`, `SEIZA_BLIND_INDEX`, `seiza setup` directories) — so `[astro]` alone works after `seiza setup`. The annotation catalogs stay off unless configured, preserving existing behavior for current configs.
- A set-but-dangling `SEIZA_*` variable or a bad explicit path disables the affected layer with a warning naming the problem (seiza 0.8.0's strict-pin errors), never a silent fallback to a different catalog.
- seiza 0.8.0 API: `Wcs` gained `sip` and `SolveHint` gained `sip_order`; the gallery pipeline stays on linear solutions since the persisted sidecar schema stores a linear WCS — no reprojection or sidecar churn from this PR.
- README `[astro]` docs rewritten around the directory form.

Existing configs are untouched: all five explicit keys keep working exactly as before.

## Test plan

- [x] `cargo test` with and without AVIF; clippy both feature sets; fmt
- [x] Backward compat: explicit-keys-only config resolves to identical paths (explicit files pass through `seiza::data_paths` unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)