### PR TITLE
Align Dependabot and Rust toolchain policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,21 @@
-# Dependabot configuration for automated dependency updates
 version: 2
 updates:
-  # Rust dependencies
-  - package-ecosystem: "cargo"
-    directory: "/"
+  - package-ecosystem: cargo
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-    open-pull-requests-limit: 10
-    labels:
-      - "dependencies"
-      - "rust"
-    commit-message:
-      prefix: "chore"
-      prefix-development: "chore"
-      include: "scope"
-    # Group minor and patch updates together
+      interval: weekly
     groups:
-      minor-and-patch:
+      cargo-dependencies:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    # But keep major updates separate
-  # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "04:00"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "github-actions"
-    commit-message:
-      prefix: "ci"
-      include: "scope"
+      interval: weekly
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       shell: powershell
 
     - name: Install Rust (use rust-toolchain.toml)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.97.1
       # Note: When rust-toolchain.toml is present, it takes precedence
       # The 'with' section is ignored when rust-toolchain.toml exists
 
@@ -196,7 +196,7 @@ jobs:
       run: npm run build
 
     - name: Install Rust (use rust-toolchain.toml)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.97.1
 
     - name: Cache cargo registry
       uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
         npm run build:prod
 
     - name: Install Rust (use rust-toolchain.toml)
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.97.1
       with:
         target: ${{ matrix.target }}
         # Note: rust-toolchain.toml specifies the version, components are installed automatically

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.1"
-components = ["rustfmt", "clippy"]
-profile = "default"
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## What changed

- group weekly Cargo and GitHub Actions dependency updates
- exclude `dtolnay/rust-toolchain` from Dependabot updates
- sync the repository toolchain and CI jobs to Rust 1.97.1
- use the minimal Rust toolchain profile with clippy and rustfmt

## Why

This aligns tenrankai with the shared dependency-update and Rust toolchain policy used across the Seiza repositories while keeping the toolchain version controlled explicitly.

## Validation

- `cargo fmt --all --check`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo test --workspace --locked --no-default-features`

The default AVIF build is blocked locally by Fedora 44's NASM 3.01, while bundled libaom still expects NASM 2.x's `-Ox` interface; the GitHub Actions platform matrix covers that native path.
